### PR TITLE
Add whenever and best_bets:sync cron job

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -16,3 +16,5 @@ require 'capistrano/bundler'
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
 
 require 'capistrano/honeybadger'
+
+require 'whenever/capistrano'

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'lograge'
 gem 'logstash-event'
 gem 'pg'
 gem 'railties'
+gem 'whenever', require: false
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     capistrano-rails (1.6.3)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
@@ -198,6 +199,8 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -234,6 +237,7 @@ DEPENDENCIES
   rubocop-rspec
   tzinfo-data
   webmock
+  whenever
 
 BUNDLED WITH
    2.4.19

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,5 +3,5 @@
 set :stage, :production
 set :rails_env, 'production'
 
-server 'allsearch-api-prod1', user: 'deploy', roles: [:app, :db]
+server 'allsearch-api-prod1', user: 'deploy', roles: [:app, :db, :prod_db]
 server 'allsearch-api-prod2', user: 'deploy', roles: [:app]

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+# 5:30 am Eastern Daylight Time, 4:30 am Eastern Standard Time
+every :day, at: '9:30am', roles: [:prod_db] do
+  rake 'best_bets:sync'
+end


### PR DESCRIPTION
Connected to #37

Verified by deploying to production using this branch. 
prod1:
```
deploy@allsearch-api-prod1:~$ crontab -l


# Begin Whenever generated tasks for: allsearch_api at: 2023-09-20 21:07:12 +0000
30 9 * * * /bin/bash -l -c 'cd /opt/allsearch_api/releases/20230920210700 && RAILS_ENV=production bundle exec rake best_bets:sync --silent'

# End Whenever generated tasks for: allsearch_api at: 2023-09-20 21:07:12 +0000
```

prod2:
```
deploy@allsearch-api-prod2:~$ crontab -l
no crontab for deploy
```