### PR TITLE
i35: add library database load cron job

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -25,3 +25,7 @@
 every :day, at: '9:30am', roles: [:prod_db] do
   rake 'best_bets:sync'
 end
+
+every :hour, roles: [:prod_db] do
+  rake 'library_databases:sync'
+end


### PR DESCRIPTION
closes #35 

I'll leave this as a draft until the top of the hour, when we can confirm that all the databases are loaded into the prod database.