### PR TITLE
i103: swagger docs should point to the same environment they are deployed to

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -24,12 +24,7 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: 'https://{defaultHost}',
-          variables: {
-            defaultHost: {
-              default: 'www.example.com'
-            }
-          }
+          url: '/'
         }
       ]
     }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -85,7 +85,4 @@ paths:
         '200':
           description: successful
 servers:
-- url: https://{defaultHost}
-  variables:
-    defaultHost:
-      default: www.example.com
+- url: "/"


### PR DESCRIPTION
closes https://github.com/pulibrary/allsearch_api/issues/103

Using the same approach as this: https://github.com/openfoodfoundation/openfoodnetwork/blob/51f125e30140ee524f1566f16d904297ae426c1e/engines/dfc_provider/spec/swagger_helper.rb#L57-L59

To exercise this on staging:

1. Deploy to staging
2. Go to https://allsearch-api-staging.princeton.edu/api-docs
3. Select an endpoint
4. Press "Try it out"
5. Enter a query
6. Confirm that you get a response.