### PR TITLE
Use `find_or_create_by` instead of `create_or_find_by`

### DIFF
--- a/app/models/libanswers.rb
+++ b/app/models/libanswers.rb
@@ -37,7 +37,7 @@ class Libanswers
   def request
     libanswers_request = Net::HTTP::Get.new(uri)
 
-    token = OAuthToken.create_or_find_by({ service: 'libanswers',
+    token = OAuthToken.find_or_create_by({ service: 'libanswers',
                                            endpoint: 'https://faq.library.princeton.edu/api/1.1/oauth/token' }).token
     libanswers_request['Authorization'] = "Bearer #{token}"
     libanswers_request

--- a/app/models/libguides.rb
+++ b/app/models/libguides.rb
@@ -46,7 +46,7 @@ class Libguides
   def request
     libguides_request = Net::HTTP::Get.new(uri)
 
-    token = OAuthToken.create_or_find_by({ service: 'libguides',
+    token = OAuthToken.find_or_create_by({ service: 'libguides',
                                            endpoint: 'https://lgapi-us.libapps.com/1.2/oauth/token' }).token
     libguides_request['Authorization'] = "Bearer #{token}"
     libguides_request

--- a/config/allsearch.yml
+++ b/config/allsearch.yml
@@ -74,6 +74,12 @@ staging:
 
 test:
   <<: *default
+  libanswers:
+    client_id: <%= 'ABC' %>
+    client_secret: <%= '12345' %>
+  libguides:
+    client_id: <%= 'ABC' %>
+    client_secret: <%= '12345' %>
 
 production:
   <<: *default

--- a/spec/models/libanswers_spec.rb
+++ b/spec/models/libanswers_spec.rb
@@ -14,4 +14,19 @@ RSpec.describe Libanswers do
       expect(libanswers.more_link).to eq('https://faq.library.princeton.edu/search/?t=0&q=root+beer')
     end
   end
+
+  describe 'with a token already in the database' do
+    before do
+      OAuthToken.create!({ service: 'libanswers',
+                           endpoint: 'https://faq.library.princeton.edu/api/1.1/oauth/token' })
+      stub_libanswers(query: 'printer', fixture: 'libanswers/printer.json')
+    end
+
+    it 'does not try to insert duplicate OAuthTokens into the database' do
+      expect do
+        service = described_class.new(query_terms: 'printer')
+        service.service_response
+      end.not_to change(OAuthToken, :count)
+    end
+  end
 end


### PR DESCRIPTION
Closes #184

- Basically, `create_or_find_by` was first trying to create a record, which was failing because of uniqueness validation on the postgres level, and this was then rescued in Ruby, and the record was found instead. Since we only ever expect to have two OAuthToken records in the database (one for libanswers, one for libguides), it makes sense to first try to find the record, then try to create it. This has the additional benefit of being faster! (see [article on create_or_find vs. find_or_create](https://www.mayerdan.com/ruby/2020/10/22/ar-find_or_create)). 
- Also added defaults to test config, so if the variables are in local environment, they will not mess up the tests