### PR TITLE
Ensure that website path is set in the staging environment

### DIFF
--- a/config/allsearch.yml
+++ b/config/allsearch.yml
@@ -76,6 +76,7 @@ staging:
       collection: "pulfalight-staging"
   library_website:
     host: "library.psb-test.princeton.edu"
+    path: "/ps-library/search/results"
 
 test:
   <<: *default


### PR DESCRIPTION
Unless we explicitly set it, it ends up being nil, since the staging website key completely overrides the website key provided by `<<: * default`, rather than inheriting from it.

closes #181 