### PR TITLE
i219: accurate count of library databases and staff

### DIFF
--- a/app/models/library_database.rb
+++ b/app/models/library_database.rb
@@ -12,7 +12,7 @@ class LibraryDatabase
   end
 
   def library_database_service_response
-    LibraryDatabaseRecord.query(query_terms).limit(3)
+    LibraryDatabaseRecord.query(query_terms)
   end
 
   def number
@@ -25,6 +25,6 @@ class LibraryDatabase
   end
 
   def documents
-    service_response
+    service_response.first(3)
   end
 end

--- a/app/models/library_staff.rb
+++ b/app/models/library_staff.rb
@@ -12,7 +12,7 @@ class LibraryStaff
   end
 
   def library_staff_service_response
-    LibraryStaffRecord.query(query_terms).limit(3)
+    LibraryStaffRecord.query(query_terms)
   end
 
   def number
@@ -25,6 +25,6 @@ class LibraryStaff
   end
 
   def documents
-    service_response
+    service_response.first(3)
   end
 end

--- a/spec/fixtures/files/library_staff/staff-directory.csv
+++ b/spec/fixtures/files/library_staff/staff-directory.csv
@@ -2,3 +2,4 @@
 "000000001","lucyfs","(555) 123-1234","Stardust, Lucy","Stardust","Lucy","Fae","Pest Removal Specialist","Pest Removal Specialist","Pest Removal Specialist","lucyfs@princeton.edu",,,"Facilities",,,,,,,,0,,"Forrestal","Recap Library"
 "000000002","nimbuskt","(555) 111-1111","Trout, Nimbus","Trout","Nimbus","Kilgore","Nap Coordinator","Nap Coordinator","Nap Coordinator","nibmus@princeton.edu",,,"Library - Office of the Deputy University Librarian",,,,,,,,0,,"A-200","Firestone Library"
 "000000003","tiberius","(555) 222-2222","Adams, Tiberius","Adams","Spot","Tiberius","Lead Hairball Engineer","Lead Hairball Engineer","Lead Hairball Engineer","tiberius@princeton.edu",,,"Library - Collections and Access Services",,,,,,,,0,,"B-300","Firestone Library"
+"000000010","brutus","(555) 222-2222","Cat, Brutus","Cat","Brutus","The","Fluffiest cat","Fluffiest cat","Fluffiest cat","brutus@princeton.edu",,,"Library - Collections and Access Services",,,,,,,,0,,"B-300","Stokes Library"

--- a/spec/requests/library_database_spec.rb
+++ b/spec/requests/library_database_spec.rb
@@ -91,6 +91,20 @@ RSpec.describe 'GET /search/database' do
     expect(response_body[:records][2][:title]).to eq('Oxford Music Online')
   end
 
+  context 'when the search query matches more than 3 results' do
+    it 'displays the total number of matches' do
+      get '/search/database?query=oxford'
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      expect(response_body[:number]).to eq(4)
+    end
+
+    it 'only includes the first three records' do
+      get '/search/database?query=oxford'
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      expect(response_body[:records].count).to eq(3)
+    end
+  end
+
   context 'with html in the description' do
     let(:libjobs_response) { file_fixture('libjobs/library-databases-html.csv') }
     let(:description) do

--- a/spec/requests/library_staff_spec.rb
+++ b/spec/requests/library_staff_spec.rb
@@ -60,4 +60,18 @@ RSpec.describe 'GET /search/staff' do
       expect(response_body[:records][0][key]).to match(expected_response[:records].first[key])
     end
   end
+
+  context 'when the search query matches more than 3 results' do
+    it 'displays the total number of matches' do
+      get '/search/staff?query=library'
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      expect(response_body[:number]).to eq(4)
+    end
+
+    it 'only includes the first three records' do
+      get '/search/staff?query=library'
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      expect(response_body[:records].count).to eq(3)
+    end
+  end
 end

--- a/spec/services/library_staff_loading_service_spec.rb
+++ b/spec/services/library_staff_loading_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe LibraryStaffLoadingService do
   end
 
   it 'creates new rows in the library_staff table for each CSV row' do
-    expect { described_class.new.run }.to change(LibraryStaffRecord, :count).by(3)
+    expect { described_class.new.run }.to change(LibraryStaffRecord, :count).by(4)
     expect(LibraryStaffRecord.third.puid).to eq(0o00000003)
     expect(LibraryStaffRecord.third.netid).to eq('tiberius')
     expect(LibraryStaffRecord.third.phone).to eq('(555) 222-2222')
@@ -25,6 +25,7 @@ RSpec.describe LibraryStaffLoadingService do
     expect(LibraryStaffRecord.third.department).to eq('Library - Collections and Access Services')
     expect(LibraryStaffRecord.third.office).to eq('B-300')
     expect(LibraryStaffRecord.third.building).to eq('Firestone Library')
+    expect(LibraryStaffRecord.fourth.first_name).to eq('Brutus')
   end
 
   it 'is idempotent' do


### PR DESCRIPTION
Thanks to @maxkadel for finding the issue -- since we were limiting our query to only 3 results, the count was only ever 0-3.

This approach has a tradeoff: we are now reading more records into memory each time.  It will likely never be a huge number of records (in the low hundreds at the very most), but an alternative approach could be to issue two db queries: one for the count, and a second for the first 3 records. Or maybe there is some Rails magic that I don't know about.

Helps with #219 