### PR TITLE
Add rubocop-rspec_rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from: .rubocop_todo.yml
 require: 
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,8 @@ group :development, :test do
   gem 'rspec_junit_formatter', require: false
   gem 'rspec-rails'
   gem 'rubocop-rails', require: false
-  gem 'rubocop-rspec'
+  gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec_rails', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,9 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rspec (3.0.1)
       rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
     ruby-progressbar (1.13.0)
     sshkit (1.23.0)
       base64
@@ -334,6 +337,7 @@ DEPENDENCIES
   rswag
   rubocop-rails
   rubocop-rspec
+  rubocop-rspec_rails
   summon
   tzinfo-data
   webmock


### PR DESCRIPTION
- Makes rubocop run marginally faster
- Gets rid of warning
- Adds some reasonable checks