### PR TITLE
[#232] Pass rescued exceptions to honeybadger

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -24,6 +24,7 @@ class ServiceController < ApplicationController
   end
 
   def show_standard_error(exception)
+    Honeybadger.notify exception
     render_error(problem: 'APPLICATION_ERROR',
                  message: "This application threw #{exception.class}",
                  status: :internal_server_error)
@@ -31,6 +32,7 @@ class ServiceController < ApplicationController
 
   # :reek:FeatureEnvy
   def show_http_error(exception)
+    Honeybadger.notify exception
     render_error(problem: 'UPSTREAM_ERROR',
                  message: "Query to upstream failed with #{exception.class}, message: #{exception.message}",
                  status: :internal_server_error)
@@ -38,12 +40,15 @@ class ServiceController < ApplicationController
 
   # :reek:FeatureEnvy
   def show_allsearch_error(exception)
+    Honeybadger.notify exception
     render_error(problem: exception.problem,
                  message: exception.message,
                  status: :internal_server_error)
   end
 
   def show_query_error
+    # We don't report these to Honeybadger, since the system is working as
+    # expected in these cases by telling the user they need to enter a query.
     render_error(problem: 'QUERY_IS_EMPTY',
                  message: 'The query param must contain non-whitespace characters.',
                  status: :bad_request)

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe CatalogController do
   context 'when service returns a Net::HTTP exception' do
     before do
       allow(Catalog).to receive(:new).and_raise(Net::HTTPFatalError.new('Some info', ''))
+      allow(Honeybadger).to receive(:notify)
     end
 
     it 'handles Net::HTTP exceptions' do
@@ -36,6 +37,7 @@ RSpec.describe CatalogController do
                                    problem: 'UPSTREAM_ERROR',
                                    message: 'Query to upstream failed with Net::HTTPFatalError, message: Some info'
                                  })
+      expect(Honeybadger).to have_received(:notify)
     end
   end
 

--- a/spec/controllers/journals_controller_spec.rb
+++ b/spec/controllers/journals_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe JournalsController do
   context 'when service returns a Net::HTTP exception' do
     before do
       allow(Journals).to receive(:new).and_raise(Net::HTTPFatalError.new('Some info', ''))
+      allow(Honeybadger).to receive(:notify)
     end
 
     it 'handles Net::HTTP exceptions' do
@@ -38,6 +39,7 @@ RSpec.describe JournalsController do
                                    problem: 'UPSTREAM_ERROR',
                                    message: 'Query to upstream failed with Net::HTTPFatalError, message: Some info'
                                  })
+      expect(Honeybadger).to have_received(:notify)
     end
   end
 

--- a/spec/requests/api/article_spec.rb
+++ b/spec/requests/api/article_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'article' do
     stub_request(:get,
                  'http://api.summon.serialssolutions.com/2.0.0/search?s.dym=t&s.fvf=ContentType,Newspaper%20Article,true&s.ho=t&s.ps=3&s.q=some_search')
       .to_return(status: 401)
+    allow(Honeybadger).to receive(:notify)
   end
 
   path '/search/article' do
@@ -63,6 +64,7 @@ RSpec.describe 'article' do
                                        problem: 'UPSTREAM_ERROR',
                                        message: 'Could not authenticate to the upstream Summon service'
                                      })
+          expect(Honeybadger).to have_received(:notify)
         end
       end
     end

--- a/spec/requests/api/catalog_spec.rb
+++ b/spec/requests/api/catalog_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'catalog' do
       .to_return(status: 200, body: file_fixture('solr/catalog/rubix.json'))
     stub_request(:get, 'http://lib-solr8-prod.princeton.edu:8983/solr/catalog-alma-production/select?facet=false&fl=id,title_display,author_display,pub_created_display,format,holdings_1display,electronic_portfolio_s,electronic_access_1display&q=some_search&rows=3&sort=score%20desc,%20pub_date_start_sort%20desc,%20title_sort%20asc')
       .to_return(status: 404, body: file_fixture('solr/catalog/404.html'))
+    allow(Honeybadger).to receive(:notify)
   end
 
   path '/search/catalog' do
@@ -65,6 +66,7 @@ RSpec.describe 'catalog' do
                                        message: 'Solr returned a 404 for path /solr/catalog-alma-production/select ' \
                                                 'on host lib-solr8-prod.princeton.edu'
                                      })
+          expect(Honeybadger).to have_received(:notify)
         end
       end
     end

--- a/spec/requests/api/journals_spec.rb
+++ b/spec/requests/api/journals_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'journals' do
       .to_return(status: 200, body: file_fixture('solr/catalog/berry_basket.json'))
     stub_request(:get, 'http://lib-solr8-prod.princeton.edu:8983/solr/catalog-alma-production/select?facet=false&fl=id,title_display,author_display,pub_created_display,format,holdings_1display,electronic_portfolio_s,electronic_access_1display&q=some_search&fq=format:Journal&rows=3&sort=score%20desc,%20pub_date_start_sort%20desc,%20title_sort%20asc')
       .to_return(status: 404, body: file_fixture('solr/catalog/404.html'))
+    allow(Honeybadger).to receive(:notify)
   end
 
   path '/search/journals' do
@@ -65,6 +66,7 @@ RSpec.describe 'journals' do
                                        message: 'Solr returned a 404 for path /solr/catalog-alma-production/select ' \
                                                 'on host lib-solr8-prod.princeton.edu'
                                      })
+          expect(Honeybadger).to have_received(:notify)
         end
       end
     end

--- a/spec/requests/api/libanswers_spec.rb
+++ b/spec/requests/api/libanswers_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'libanswers' do
         before do
           stub_request(:post, 'https://faq.library.princeton.edu/api/1.1/oauth/token')
             .to_return(status: 400, body: '{"error":"The client credentials are invalid"}')
+          allow(Honeybadger).to receive(:notify)
         end
 
         run_test! do |response|
@@ -55,6 +56,7 @@ RSpec.describe 'libanswers' do
                                        problem: 'UPSTREAM_ERROR',
                                        message: 'Could not generate a valid authentication token with upstream service.'
                                      })
+          expect(Honeybadger).to have_received(:notify)
         end
       end
     end

--- a/spec/requests/api/libguides_spec.rb
+++ b/spec/requests/api/libguides_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'libguides' do
         before do
           stub_request(:post, 'https://lgapi-us.libapps.com/1.2/oauth/token')
             .to_return(status: 400, body: '{"error":"The client credentials are invalid"}')
+          allow(Honeybadger).to receive(:notify)
         end
 
         run_test! do |response|
@@ -64,6 +65,7 @@ RSpec.describe 'libguides' do
                                        problem: 'UPSTREAM_ERROR',
                                        message: 'Could not generate a valid authentication token with upstream service.'
                                      })
+          expect(Honeybadger).to have_received(:notify)
         end
       end
     end

--- a/spec/requests/library_website_spec.rb
+++ b/spec/requests/library_website_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'GET /search/website' do
       stub_request(:post, url)
         .with(body: { 'search' => 'root' })
         .to_return(status: 503)
+      allow(Honeybadger).to receive(:notify)
     end
 
     it 'gives the user a 500 error and a descriptive message' do
@@ -19,6 +20,7 @@ RSpec.describe 'GET /search/website' do
                                    problem: 'UPSTREAM_ERROR',
                                    message: 'The library website API returned a 503 HTTP status code.'
                                  })
+      expect(Honeybadger).to have_received(:notify)
     end
   end
 end


### PR DESCRIPTION
closes #232 

See [this honeybadger as an example that came in with this branch deployed](https://app.honeybadger.io/projects/114176/faults/108992237).