### PR TITLE
Add health endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'activesupport'
 gem 'bootsnap', require: false
 gem 'ddtrace', require: 'ddtrace/auto_instrument'
 gem 'dogstatsd-ruby'
+gem 'health-monitor-rails'
 gem 'honeybadger'
 gem 'lograge'
 gem 'logstash-event'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     hashdiff (1.1.0)
+    health-monitor-rails (12.1.0)
+      railties (>= 6.1)
     honeybadger (5.13.3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -323,6 +325,7 @@ DEPENDENCIES
   ddtrace
   dogstatsd-ruby
   ed25519
+  health-monitor-rails
   honeybadger
   lograge
   logstash-event

--- a/app/checks/solr_status.rb
+++ b/app/checks/solr_status.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class SolrStatus < HealthMonitor::Providers::Base
+  def check!
+    response = Net::HTTP.get_response(status_uri)
+    json = JSON.parse(response.body)
+    raise "The solr has an invalid status #{status_uri}" if json['responseHeader']['status'] != 0
+  end
+
+  # We will want to be able to check both solr8 and solr9 cores
+  # Right now we're checking "whatever dpul's host is"
+  def solr_config
+    Rails.application.config_for(:allsearch)[:dpul][:solr]
+  end
+
+  def status_uri
+    URI::HTTP.build(host: solr_config[:host],
+                    port: solr_config[:port],
+                    path: '/solr/admin/cores',
+                    query: 'action=STATUS')
+  end
+end

--- a/app/models/concerns/solr.rb
+++ b/app/models/concerns/solr.rb
@@ -26,6 +26,20 @@ module Solr
     @documents ||= service_response[:response][:docs]
   end
 
+  def self.status_uris
+    solr_services_configs.map do |_name, config|
+      solr_config = config[:solr]
+      URI::HTTP.build(host: solr_config[:host],
+                      port: solr_config[:port],
+                      path: '/solr/admin/cores',
+                      query: 'action=STATUS')
+    end.uniq.compact
+  end
+
+  def self.solr_services_configs
+    Rails.application.config_for(:allsearch).select { |_key, value| value.keys.include?(:solr) }
+  end
+
   private
 
   # :reek:ManualDispatch

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  HealthMonitor.configure do |config|
+    config.cache
+    # includes database check by default
+    config.add_custom_provider(SolrStatus)
+    # Make this health check available at /health
+    config.path = :health
+
+    # Notify Honeybadger if there is a failed health check
+    config.error_callback = proc do |e|
+      Rails.logger.error "Health check failed with: #{e.message}"
+      Honeybadger.notify(e)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
+  mount HealthMonitor::Engine, at: '/' # Can see at /health
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/spec/checks/solr_status_spec.rb
+++ b/spec/checks/solr_status_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SolrStatus do
+  let(:solr_status) { described_class.new }
+
+  context 'with a successful request to solr' do
+    before do
+      stub_request(:get, 'http://lib-solr8-prod.princeton.edu:8983/solr/admin/cores?action=STATUS').to_return(
+        body: { responseHeader: { status: 0 } }.to_json, headers: { 'Content-Type' => 'text/json' }
+      )
+    end
+
+    it 'returns nil on the check! method' do
+      expect(solr_status.check!).to be_nil
+    end
+  end
+
+  context 'with an unsuccessful request to solr' do
+    before do
+      stub_request(:get, 'http://lib-solr8-prod.princeton.edu:8983/solr/admin/cores?action=STATUS').to_return(
+        body: { responseHeader: { status: 500 } }.to_json, headers: { 'Content-Type' => 'text/json' }
+      )
+    end
+
+    it 'raises an error' do
+      expect { solr_status.check! }.to raise_error(RuntimeError, /The solr has an invalid status/)
+    end
+  end
+end

--- a/spec/models/concerns/solr_spec.rb
+++ b/spec/models/concerns/solr_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Solr do
+  describe '#status_uris' do
+    let(:expected_solr8_uri) do
+      URI::HTTP.build(host: 'lib-solr8-prod.princeton.edu',
+                      port: '8983',
+                      path: '/solr/admin/cores',
+                      query: 'action=STATUS')
+    end
+
+    it 'has an array of status uris' do
+      expect(described_class.status_uris).to contain_exactly(expected_solr8_uri)
+    end
+  end
+end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Health Check' do
+  describe 'GET /health' do
+    it 'has a health check' do
+      stub_request(:get, 'http://lib-solr8-prod.princeton.edu:8983/solr/admin/cores?action=STATUS').to_return(
+        body: { responseHeader: { status: 0 } }.to_json, headers: { 'Content-Type' => 'text/json' }
+      )
+
+      get '/health.json'
+      expect(response).to be_successful
+    end
+
+    it 'errors when a service is down' do
+      stub_request(:get, 'http://lib-solr8-prod.princeton.edu:8983/solr/admin/cores?action=STATUS').to_return(
+        body: { responseHeader: { status: 500 } }.to_json, headers: { 'Content-Type' => 'text/json' }
+      )
+
+      get '/health.json'
+
+      expect(response).not_to be_successful
+      expect(response).to have_http_status :service_unavailable
+      solr_response = response.parsed_body['results'].find { |x| x['name'] == 'SolrStatus' }
+      expect(solr_response['message']).to start_with 'The solr has an invalid status'
+    end
+  end
+end


### PR DESCRIPTION
Right now only checks dpul's host / port (which right now is the same as every other solr app's host and port)