### PR TITLE
Handle decomposed diacritics in more_link 

### DIFF
--- a/app/models/library_database.rb
+++ b/app/models/library_database.rb
@@ -22,7 +22,10 @@ class LibraryDatabase
   # The libguides search does not treat accented characters consistently
   # Always use the unaccented version for the "more_link"
   def transliterated_escaped_terms
-    URI::DEFAULT_PARSER.escape(I18n.transliterate(unescaped_terms))
+    diacritic_combining_characters = [*0x1DC0..0x1DFF, *0x0300..0x036F, *0xFE20..0xFE2F].pack('U*')
+    decomposed_version = unescaped_terms.unicode_normalize(:nfd)
+    decomposed_without_combining_characters = decomposed_version.tr(diacritic_combining_characters, '')
+    URI::DEFAULT_PARSER.escape(decomposed_without_combining_characters)
   end
 
   def number

--- a/app/models/library_database.rb
+++ b/app/models/library_database.rb
@@ -30,7 +30,7 @@ class LibraryDatabase
   end
 
   def more_link
-    URI::HTTPS.build(host: 'libguides.princeton.edu', path: '/az.php',
+    URI::HTTPS.build(host: 'libguides.princeton.edu', path: '/az/databases',
                      query: "q=#{transliterated_escaped_terms}")
   end
 

--- a/spec/models/library_database_record_spec.rb
+++ b/spec/models/library_database_record_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe LibraryDatabaseRecord do
       it 'matches the sort from the original service' do
         pending('Waiting for more insight into LibGuides search')
         query_response = described_class.query('oxford music').with_pg_search_rank
-        # The order from Libguides search https://libguides.princeton.edu/az.php?q=oxford%20music
+        # The order from Libguides search https://libguides.princeton.edu/az/databases?q=oxford%20music
         expect(query_response[0].name).to eq('Oxford Scholarship Online:  Music')
         expect(query_response[1].name).to eq('Oxford Bibliographies: Music')
         expect(query_response[2].name).to eq('Oxford Music Online')

--- a/spec/models/library_database_spec.rb
+++ b/spec/models/library_database_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LibraryDatabase do
   let(:db_service) { described_class.new(query_terms:) }
 
   it 'has the correct more_link' do
-    expect(db_service.more_link.to_s).to eq('https://libguides.princeton.edu/az.php?q=foo')
+    expect(db_service.more_link.to_s).to eq('https://libguides.princeton.edu/az/databases?q=foo')
   end
 
   context 'with accents in in the query terms' do
@@ -28,7 +28,7 @@ RSpec.describe LibraryDatabase do
     end
 
     it 'builds a working more_link' do
-      expect(db_service.more_link.to_s).to eq('https://libguides.princeton.edu/az.php?q=Kobunso%20Taika%20Koshomoku')
+      expect(db_service.more_link.to_s).to eq('https://libguides.princeton.edu/az/databases?q=Kobunso%20Taika%20Koshomoku')
     end
   end
 end

--- a/spec/models/library_database_spec.rb
+++ b/spec/models/library_database_spec.rb
@@ -30,5 +30,13 @@ RSpec.describe LibraryDatabase do
     it 'builds a working more_link' do
       expect(db_service.more_link.to_s).to eq('https://libguides.princeton.edu/az/databases?q=Kobunso%20Taika%20Koshomoku')
     end
+
+    context 'when the diacritics are decomposed into two separate characters' do
+      let(:query_terms) { 'Ko%CC%84bunso%CC%84%20Taika%20Koshomoku' }
+
+      it 'builds a working more_link' do
+        expect(db_service.more_link.to_s).to eq('https://libguides.princeton.edu/az/databases?q=Kobunso%20Taika%20Koshomoku')
+      end
+    end
   end
 end

--- a/spec/requests/library_database_spec.rb
+++ b/spec/requests/library_database_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'GET /search/database' do
     get '/search/database?query=oxford music'
 
     response_body = JSON.parse(response.body, symbolize_names: true)
-    # The order from Libguides search https://libguides.princeton.edu/az.php?q=oxford%20music
+    # The order from Libguides search https://libguides.princeton.edu/az/databases?q=oxford%20music
     expect(response_body[:records][0][:title]).to eq('Oxford Scholarship Online:  Music')
     expect(response_body[:records][1][:title]).to eq('Oxford Bibliographies: Music')
     expect(response_body[:records][2][:title]).to eq('Oxford Music Online')

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -651,7 +651,7 @@ paths:
               example:
                 number: 0
                 records: []
-                more: https://libguides.princeton.edu/az.php?q=oxford%20music
+                more: https://libguides.princeton.edu/az/databases?q=oxford%20music
         '400':
           description: with a search query that only contains whitespace
           content:


### PR DESCRIPTION
closes #292 

It also updates the more_link URL to springshare's new url -- it seemed that some characters were also being mangled in the redirect.