### PR TITLE
[#294] Normalize Best Bet indexing and searching without diacritics

### DIFF
--- a/app/models/best_bet_record.rb
+++ b/app/models/best_bet_record.rb
@@ -4,13 +4,13 @@
 # metadata from the best_bet_record table in the database
 class BestBetRecord < ApplicationRecord
   validates :title, :url, :search_terms, presence: true
-  scope :query, ->(search_term) { where('? ILIKE ANY(search_terms)', search_term) }
+  scope :query, ->(search_term) { where('unaccent(?) ILIKE ANY(search_terms)', search_term) }
   def self.new_from_csv(row)
     BestBetRecord.create!(
       title: row[0],
       description: row[1],
       url: row[2],
-      search_terms: row[3]&.split(', '),
+      search_terms: row[3]&.split(', ')&.map { |term| Normalizer.new(term).without_diacritics },
       last_update: last_update(row)
     )
   rescue ActiveRecord::RecordInvalid => error

--- a/app/models/library_database.rb
+++ b/app/models/library_database.rb
@@ -22,10 +22,7 @@ class LibraryDatabase
   # The libguides search does not treat accented characters consistently
   # Always use the unaccented version for the "more_link"
   def transliterated_escaped_terms
-    diacritic_combining_characters = [*0x1DC0..0x1DFF, *0x0300..0x036F, *0xFE20..0xFE2F].pack('U*')
-    decomposed_version = unescaped_terms.unicode_normalize(:nfd)
-    decomposed_without_combining_characters = decomposed_version.tr(diacritic_combining_characters, '')
-    URI::DEFAULT_PARSER.escape(decomposed_without_combining_characters)
+    URI::DEFAULT_PARSER.escape(Normalizer.new(unescaped_terms).without_diacritics)
   end
 
   def number

--- a/app/models/normalizer.rb
+++ b/app/models/normalizer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Normalizer
+  def initialize(term)
+    @term = term
+  end
+
+  def without_diacritics
+    @without_diacritics ||= begin
+      diacritic_combining_characters = [*0x1DC0..0x1DFF, *0x0300..0x036F, *0xFE20..0xFE2F].pack('U*')
+      decomposed_version = term.unicode_normalize(:nfd)
+      decomposed_version.tr(diacritic_combining_characters, '')
+    end
+  end
+
+  private
+
+  attr_reader :term
+end

--- a/spec/models/best_bet_record_spec.rb
+++ b/spec/models/best_bet_record_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe BestBetRecord do
       let(:search_terms) { ['annee philologique', "l'annee", "l'annee philologique"] }
 
       it 'can find the record regardless of diacritics' do
-        pending('Fixing diacritics search')
         # These searches also seem to behave differently depending on if they have the "l'" or not
         doc1 = described_class.create!(title:, url:, search_terms:)
         expect(described_class.query(unaccented)).to contain_exactly(doc1) # found
@@ -101,6 +100,22 @@ RSpec.describe BestBetRecord do
         expect(record).to be_nil
         expect(Rails.logger).to have_received(:error).with("Could not create new BestBet for row #{row}: " \
                                                            "Validation failed: Search terms can't be blank")
+      end
+    end
+
+    context 'when search terms contain precomposed diacritics' do
+      let(:search_terms) { "l'Année" }
+
+      it 'normalizes the terms to not contain diacritics' do
+        expect(record.search_terms).to contain_exactly("l'Annee")
+      end
+    end
+
+    context 'when search terms contain decomposed diacritics' do
+      let(:search_terms) { "l'Année" }
+
+      it 'normalizes the terms to not contain diacritics' do
+        expect(record.search_terms).to contain_exactly("l'Annee")
       end
     end
 

--- a/spec/models/normalizer_spec.rb
+++ b/spec/models/normalizer_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Normalizer do
+  describe '#without_diacritics' do
+    it 'removes precomposed diacritics' do
+      expect(described_class.new("l'Année").without_diacritics).to eq("l'Annee")
+    end
+
+    it 'removes decomposed diacritics' do
+      expect(described_class.new("l'Année").without_diacritics).to eq("l'Annee")
+    end
+  end
+end


### PR DESCRIPTION
closes #294 

@maxkadel and I discussed using a different approach for BestBets than for the LibraryStaff and LibraryDatabases.  Since those do full-text searching, while this one merely matches the string, they can use a FTS configuration, while this just normalizes on the Ruby side.