### PR TITLE
[#301] Include title matches in best bet search results

### DIFF
--- a/app/models/best_bet_record.rb
+++ b/app/models/best_bet_record.rb
@@ -4,7 +4,9 @@
 # metadata from the best_bet_record table in the database
 class BestBetRecord < ApplicationRecord
   validates :title, :url, :search_terms, presence: true
-  scope :query, ->(search_term) { where('unaccent(?) ILIKE ANY(search_terms)', search_term) }
+  scope :query, lambda { |search_term|
+                  where('unaccent(?) ILIKE ANY(search_terms) OR unaccent(?) ILIKE title', search_term, search_term)
+                }
   def self.new_from_csv(row)
     BestBetRecord.create!(
       title: row[0],

--- a/spec/models/best_bet_record_spec.rb
+++ b/spec/models/best_bet_record_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe BestBetRecord do
       expect(described_class.query('dogs')).to contain_exactly(doc1, doc3)
     end
 
+    it 'finds matches in the title field' do
+      doc1 = described_class.create(title:, url:, search_terms: %w[dogs cats])
+      expect(described_class.query('digital sanborn maps')).to contain_exactly(doc1)
+    end
+
     it 'is case-insensitive' do
       doc1 = described_class.create(title:, url:, search_terms: %w[dogs cATs])
       expect(described_class.query('Dogs')).to contain_exactly(doc1)


### PR DESCRIPTION
Prior to this commit, we only considered matches in the search_terms field.

Closes #301.