### PR TITLE
Ignore personal data bearer warnings

### DIFF
--- a/bearer.ignore
+++ b/bearer.ignore
@@ -1,0 +1,26 @@
+{
+  "e5e17cede9a731da09a639c9c78af007_0": {
+    "author": "Max Kadel",
+    "comment": "This information is publicly accessible via both the website and the API. If we want to lock it down, we should do it there first, and then encrypt it.",
+    "false_positive": false,
+    "ignored_at": "2025-02-12T20:11:05Z"
+  },
+  "e5e17cede9a731da09a639c9c78af007_1": {
+    "author": "Max Kadel",
+    "comment": " This information is publicly accessible via both the website and the API. If we want to lock it down, we should do it there first, and then encrypt it.",
+    "false_positive": false,
+    "ignored_at": "2025-02-12T20:12:02Z"
+  },
+  "e5e17cede9a731da09a639c9c78af007_2": {
+    "author": "Max Kadel",
+    "comment": "This information is publicly accessible via both the website and the API. If we want to lock it down, we should do it there first, and then encrypt it.",
+    "false_positive": false,
+    "ignored_at": "2025-02-12T20:12:35Z"
+  },
+  "e5e17cede9a731da09a639c9c78af007_3": {
+    "author": "Max Kadel",
+    "comment": " This information is publicly accessible via both the website and the API. If we want to lock it down, we should do it there first, and then encrypt it.",
+    "false_positive": false,
+    "ignored_at": "2025-02-12T20:12:53Z"
+  }
+}

--- a/bearer.yml
+++ b/bearer.yml
@@ -12,7 +12,7 @@ rule:
     only-rule: []
     # Tickets to remediate these rules and remove from this stanza:
     #   ruby_rails_default_encryption - https://github.com/pulibrary/allsearch_api/issues/309
-    skip-rule: [ruby_rails_default_encryption]
+    skip-rule: []
 scan:
     context: ""
     data_subject_mapping: ""


### PR DESCRIPTION
- If we want to protect this data, it makes more sense to protect it on the website and the API first, and then encrypt the database.

Closes #309