### PR TITLE
bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,6 @@ GEM
       logger
       msgpack
     datadog-ruby_core_source (3.4.1)
-    date (3.4.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.6.6)
@@ -114,7 +113,6 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     ed25519 (1.4.0)
-    erb (5.0.1)
     erubi (1.13.1)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-darwin)
@@ -132,11 +130,6 @@ GEM
       ostruct
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.0)
-    irb (1.15.2)
-      pp (>= 0.6.0)
-      rdoc (>= 4.0.0)
-      reline (>= 0.4.2)
     json (2.12.2)
     json-schema (5.1.1)
       addressable (~> 2.8)
@@ -159,11 +152,6 @@ GEM
     method_source (1.1.0)
     minitest (5.25.5)
     msgpack (1.8.0)
-    net-scp (4.1.0)
-      net-ssh (>= 2.6.5, < 8.0.0)
-    net-sftp (4.0.0)
-      net-ssh (>= 5.0.0, < 8.0.0)
-    net-ssh (7.3.0)
     nio4r (2.7.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
@@ -177,9 +165,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
-    pp (0.6.2)
-      prettyprint
-    prettyprint (0.2.0)
     prism (1.4.0)
     pry (0.15.2)
       coderay (~> 1.1)
@@ -187,9 +172,6 @@ GEM
     pry-byebug (3.11.0)
       byebug (~> 12.0)
       pry (>= 0.13, < 0.16)
-    psych (5.2.6)
-      date
-      stringio
     public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
@@ -205,8 +187,6 @@ GEM
       rack (>= 1.3)
     rack-utf8_sanitizer (1.10.1)
       rack (>= 1.0, < 4.0)
-    rackup (2.2.1)
-      rack (>= 3)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -214,23 +194,15 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails_semantic_logger (4.17.0)
-      irb (~> 1.13)
+    rails_semantic_logger (4.18.0)
       rack
-      rackup (>= 1.0.0)
       railties (>= 5.1)
-      rake (>= 12.2)
       semantic_logger (~> 4.16)
-      thor (~> 1.0, >= 1.2.2)
-      zeitwerk (~> 2.6)
     railties (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
     rainbow (3.1.1)
     rake (13.3.0)
-    rdoc (6.14.0)
-      erb
-      psych (>= 4.0.0)
     reek (6.5.0)
       dry-schema (~> 1.13)
       logger (~> 1.6)
@@ -238,8 +210,6 @@ GEM
       rainbow (>= 2.0, < 4.0)
       rexml (~> 3.1)
     regexp_parser (2.10.0)
-    reline (0.6.1)
-      io-console (~> 0.5)
     rexml (3.4.1)
     rspec-core (3.13.4)
       rspec-support (~> 3.13.0)
@@ -305,13 +275,7 @@ GEM
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     semantic_logger (4.16.1)
-      base64
       concurrent-ruby (~> 1.0)
-      logger
-      net-scp (>= 1.1.2)
-      net-sftp (>= 2.1.2)
-      net-ssh (>= 2.8.0)
-      ostruct
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -319,10 +283,8 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     sshkit (1.24.0)
-    stringio (3.1.7)
     summon (2.0.5)
       json
-    thor (1.3.2)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
to install rails_semantic_logger 4.18.0