### PR TITLE
Explicitly include Rake in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,10 +20,12 @@ gem 'rack-cors'
 gem 'rack-utf8_sanitizer'
 gem 'rails_semantic_logger'
 gem 'railties', '~> 8.0'
+gem 'rake'
 gem 'rswag'
 gem 'summon'
 gem 'tzinfo-data', '~> 1.2025'
 gem 'whenever', require: false
+gem 'zeitwerk'
 
 group :development do
   gem 'bcrypt_pbkdf'
@@ -32,6 +34,8 @@ group :development do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
   gem 'ed25519'
+  gem 'net-scp'
+  gem 'net-ssh'
   gem 'puma'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,9 @@ GEM
     method_source (1.1.0)
     minitest (5.25.5)
     msgpack (1.8.0)
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-ssh (7.3.0)
     nio4r (2.7.4)
     nokogiri (1.18.9-arm64-darwin)
       racc (~> 1.4)
@@ -332,6 +335,8 @@ DEPENDENCIES
   health-monitor-rails
   honeybadger
   logstash-event
+  net-scp
+  net-ssh
   pg
   pry-byebug
   puma
@@ -339,6 +344,7 @@ DEPENDENCIES
   rack-utf8_sanitizer
   rails_semantic_logger
   railties (~> 8.0)
+  rake
   reek
   rspec-rails
   rspec_junit_formatter
@@ -351,6 +357,7 @@ DEPENDENCIES
   tzinfo-data (~> 1.2025)
   webmock
   whenever
+  zeitwerk
 
 BUNDLED WITH
    2.6.2


### PR DESCRIPTION
When we deployed, it gave various errors:
* can't find executable rake for gem rake.
* cannot load such file -- net/ssh/proxy/command (LoadError)
* cannot load such file -- net/scp (LoadError)
* cannot load such file -- zeitwerk (LoadError)

This commit explicitly includes rake, zeitwerk, net-scp, and net-ssh in the Gemfile, which appears to resolve the issue.