### PR TITLE
Extract ROM repository creation into a factory

### DIFF
--- a/app/controllers/banner_controller.rb
+++ b/app/controllers/banner_controller.rb
@@ -2,7 +2,7 @@
 
 class BannerController
   def self.call(env)
-    banner_repo = BannerRepository.new env['rom']
+    banner_repo = RepositoryFactory.new(env['rom']).banner
     banner_json = banner_repo.banners.first.as_json
     [200, { 'Content-Type' => 'application/json; charset=utf-8' }, [banner_json]]
   end

--- a/app/repositories/repository_factory.rb
+++ b/app/repositories/repository_factory.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RepositoryFactory
+  [:banner, :library_database].each do |method_name|
+    define_singleton_method method_name do
+      return instance_variable_get("@#{method_name}") if instance_variable_defined?("@#{method_name}")
+
+      instance_variable_set("@#{method_name}", new.send(method_name))
+    end
+  end
+
+  # Over time, we can gradually move from Rails.application.config.rom (the Rails way to access ROM)
+  # to env['rom'] (the Rack way)
+  def initialize(rom = Rails.application.config.rom)
+    @rom = rom
+  end
+
+  def banner
+    BannerRepository.new(rom)
+  end
+
+  def library_database
+    LibraryDatabaseRepository.new(rom)
+  end
+
+  private
+
+  attr_reader :rom
+end

--- a/app/services/library_database_loading_service.rb
+++ b/app/services/library_database_loading_service.rb
@@ -21,6 +21,10 @@ class LibraryDatabaseLoadingService < CSVLoadingService
   end
 
   def repository
-    @repository ||= LibraryDatabaseRepository.new(Rails.application.config.rom)
+    @repository ||= repository_factory.library_database
+  end
+
+  def repository_factory
+    @repository_factory ||= RepositoryFactory.new
   end
 end

--- a/benchmark/microbenchmarks.rb
+++ b/benchmark/microbenchmarks.rb
@@ -4,7 +4,7 @@ require 'benchmark/ips'
 require_relative '../config/environment'
 
 Benchmark.ips do |b|
-  library_database_repo = LibraryDatabaseRepository.new Rails.application.config.rom
+  library_database_repo = RepositoryFactory.library_database
   csv = CSV.read Rails.root.join('spec/fixtures/files/libjobs/library-databases.csv'), headers: true
   b.report('LibraryDatabaseRepository#create_from_csv') do
     library_database_repo.create_from_csv csv

--- a/lib/tasks/banner.rake
+++ b/lib/tasks/banner.rake
@@ -3,14 +3,14 @@
 namespace :banner do
   desc 'Update banner [text,alert_status[info|success|warning|error],dismissible,autoclear]'
   task :update, [:text, :alert_status, :dismissible, :autoclear] => :environment do |_task, args|
-    banner_repo = BannerRepository.new Rails.application.config.rom
+    banner_repo = RepositoryFactory.banner
     banner_repo.modify args.to_h
     Rake::Task['banner:show'].invoke
   end
 
   desc 'Show current banner configuration'
   task show: :environment do
-    banner_repo = BannerRepository.new Rails.application.config.rom
+    banner_repo = RepositoryFactory.banner
     banner = banner_repo.banners.first
     if banner
       puts "The currently set banner text is: #{banner.text}\n"

--- a/spec/relations/library_database_relation_spec.rb
+++ b/spec/relations/library_database_relation_spec.rb
@@ -3,14 +3,12 @@
 require 'rails_helper'
 
 # rubocop:disable RSpec/NestedGroups
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe LibraryDatabaseRelation do
-  let(:rom) { Rails.application.config.rom }
-  let(:library_databases) { rom.relations[:library_database_records] }
+  let(:library_databases) { Rails.application.config.rom.relations[:library_database_records] }
 
   describe '#query' do
     before do
-      repo = LibraryDatabaseRepository.new(rom)
+      repo = RepositoryFactory.library_database
       repo.create(name: 'Resource',
                   alt_names_concat: 'EBSCO; JSTOR',
                   libguides_id: 1,
@@ -105,4 +103,3 @@ RSpec.describe LibraryDatabaseRelation do
   end
 end
 # rubocop:enable RSpec/NestedGroups
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/services/library_database_loading_service_spec.rb
+++ b/spec/services/library_database_loading_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe LibraryDatabaseLoadingService do
 
     it 'does not proceed' do
       rom = Rails.application.config.rom
-      repo = LibraryDatabaseRepository.new(rom)
+      repo = RepositoryFactory.library_database
       repo.create(libguides_id: 123, name: 'JSTOR')
       expect { described_class.new.run }.not_to(change { rom.relations[:library_database_records].count })
     end
@@ -42,7 +42,7 @@ RSpec.describe LibraryDatabaseLoadingService do
   context 'when a library database in postgres is no longer in the CSV' do
     it 'removes it from the database' do
       rom = Rails.application.config.rom
-      repo = LibraryDatabaseRepository.new(rom)
+      repo = RepositoryFactory.library_database
       repo.create(libguides_id: 123, name: 'JSTOR')
       expect(rom.relations[:library_database_records].where(libguides_id: 123).count).to eq 1
       described_class.new.run
@@ -53,7 +53,7 @@ RSpec.describe LibraryDatabaseLoadingService do
   context 'when a library database has updated info in the CSV' do
     it 'updates the relevant fields' do
       rom = Rails.application.config.rom
-      repo = LibraryDatabaseRepository.new(rom)
+      repo = RepositoryFactory.library_database
       repo.create(libguides_id: 2_938_694, name: 'JSTOR')
       expect(
         rom.relations[:library_database_records].where(libguides_id: 2_938_694).first[:name]
@@ -68,7 +68,7 @@ RSpec.describe LibraryDatabaseLoadingService do
   context 'when the CSV is suspiciously small relative to the number of database rows' do
     it 'does not proceed' do
       rom = Rails.application.config.rom
-      repo = LibraryDatabaseRepository.new(rom)
+      repo = RepositoryFactory.library_database
       30.times { |number| repo.create(libguides_id: number, name: 'JSTOR') }
       expect { described_class.new.run }.not_to(change { rom.relations[:library_database_records].count })
     end


### PR DESCRIPTION
As we gradually move away from using Rails abstractions, this can hopefully provide a bit of a bridge between calling `Rails.application.config.rom` and calling `env['rom']`.