### PR TITLE
Remove parallelism from Circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,6 @@ jobs:
           command: bundle exec reek app
   test:
     executor: allsearch-executor
-    parallelism: 3
     steps:
       - attach_workspace:
           at: '~/allsearch_api'


### PR DESCRIPTION
The tests are quite fast for this project, and the overhead of parallelism can actually slow them down (especially if one of the parallel runs is slow to download an image or similar).