### PR TITLE
Address bug when starting dev servers locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'csv'
 gem 'datadog', '~> 2.0', require: 'datadog/auto_instrument'
 gem 'dogstatsd-ruby'
 gem 'dry-monads'
-gem 'flipper-sequel'
+gem 'flipper-sequel', require: false
 gem 'health-monitor-rails'
 gem 'honeybadger'
 gem 'logstash-event'

--- a/app/models/library_website.rb
+++ b/app/models/library_website.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'flipper'
+
 class LibraryWebsite
   include Parsed
 

--- a/app/repositories/banner_repository.rb
+++ b/app/repositories/banner_repository.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rom-repository'
+require 'flipper'
 
 # This repository translates between the objects and methods in our repository and the data and queries in our database
 # To instantiate:

--- a/config/db_connection.rb
+++ b/config/db_connection.rb
@@ -4,8 +4,12 @@ require 'erb'
 require 'sequel'
 require 'yaml'
 
-path = "#{__dir__}/database.yml"
-db_config = YAML.safe_load(ERB.new(File.read(path)).result, aliases: true)[Rails.env]
+begin
+  path = "#{__dir__}/database.yml"
+  db_config = YAML.safe_load(ERB.new(File.read(path)).result, aliases: true)[Rails.env]
 
-DB = Sequel.postgres(db_config['database'], user: db_config['username'], password: db_config['password'],
-                                            host: db_config['host'], port: db_config['port'])
+  DB = Sequel.postgres(db_config['database'], user: db_config['username'], password: db_config['password'],
+                                              host: db_config['host'], port: db_config['port'])
+rescue StandardError
+  nil
+end


### PR DESCRIPTION
If lando is not yet running, the lando_env ruby file does not set the relevant lando environment variables, and the db_connection ruby file then cannot create a valid Sequel connection, leading to the following error:

```
Sequel::DatabaseConnectionError: PG::ConnectionBad: connection to server at "127.0.0.1", port 5432 failed: Connection refused (Sequel::DatabaseConnectionError)
```

Instead, we rescue from this error, and wait to load Flipper classes (which rely on a valid Sequel connection) until we actually need them.

This regression was introduced in #420.