### PR TITLE
Remove ActiveModel::API from various classes

### DIFF
--- a/app/models/art_museum.rb
+++ b/app/models/art_museum.rb
@@ -2,7 +2,6 @@
 
 # This class is responsible for querying the Art Museum API
 class ArtMuseum
-  include ActiveModel::API
   include Parsed
 
   attr_reader :service, :service_response

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,7 +2,6 @@
 
 # This class is responsible for querying the Summon API, aka "Articles+"
 class Article
-  include ActiveModel::API
   include Parsed
 
   attr_reader :query_terms, :service

--- a/app/models/catalog.rb
+++ b/app/models/catalog.rb
@@ -2,7 +2,6 @@
 
 # This class is responsible for querying the Catalog
 class Catalog
-  include ActiveModel::API
   include Parsed
   include Solr
 

--- a/app/models/dpul.rb
+++ b/app/models/dpul.rb
@@ -2,7 +2,6 @@
 
 # This class is responsible for querying DPUL
 class Dpul
-  include ActiveModel::API
   include Parsed
   include Solr
 

--- a/app/models/findingaids.rb
+++ b/app/models/findingaids.rb
@@ -2,7 +2,6 @@
 
 # This class is responsible for querying Findingaids (aka PULFAlight)
 class Findingaids
-  include ActiveModel::API
   include Parsed
   include Solr
 

--- a/app/models/pulmap.rb
+++ b/app/models/pulmap.rb
@@ -2,7 +2,6 @@
 
 # This class is responsible for querying maps.princeton.edu (aka Pulmap)
 class Pulmap
-  include ActiveModel::API
   include Parsed
   include Solr
 


### PR DESCRIPTION
We don't actually use any of the functionality that this module provides