### PR TITLE
Remove rspec-rails rubocop plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,6 @@ inherit_from: .rubocop_todo.yml
 plugins: 
   - rubocop-rails
   - rubocop-rspec
-  - rubocop-rspec_rails
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group :development, :test do
   gem 'rswag-specs'
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'rubocop-rspec_rails', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,10 +315,6 @@ GEM
     rubocop-rspec (3.6.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
-    rubocop-rspec_rails (2.31.0)
-      lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
-      rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     semantic_logger (4.16.1)
@@ -412,7 +408,6 @@ DEPENDENCIES
   rswag-specs
   rubocop-rails
   rubocop-rspec
-  rubocop-rspec_rails
   sequel-activerecord_connection
   simplecov
   summon


### PR DESCRIPTION
We are working on removing rspec-rails (and rails), so we no longer will need this.

Helps with #409