### PR TITLE
Replace Rails.root with our own method

### DIFF
--- a/app/checks/check_list.rb
+++ b/app/checks/check_list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../paths'
+
 # This class maintains a list of health checks
 class CheckList
   def initialize(env)
@@ -31,7 +33,7 @@ class CheckList
 
   def critical_checks
     {
-      'remove-from-nginx file is not present' => FileDoesNotExistCheck.new("#{__dir__}/../../public/remove-from-nginx")
+      'remove-from-nginx file is not present' => FileDoesNotExistCheck.new(allsearch_path('public/remove-from-nginx'))
     }
   end
 
@@ -64,7 +66,7 @@ class CheckList
   end
 
   def solr_config_path
-    "#{__dir__}/../../config/allsearch.yml"
+    allsearch_path 'config/allsearch.yml'
   end
 
   def solr_configs

--- a/app/controllers/open_api_spec_controller.rb
+++ b/app/controllers/open_api_spec_controller.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require_relative '../paths'
+
 # This module is responsible for serving computer-readable API documentation as YAML
 module OpenApiSpecController
   def self.call(_env)
     [
       200,
       {},
-      File.readlines("#{__dir__}/../../swagger/v1/swagger.yaml")
+      File.readlines(allsearch_path('swagger/v1/swagger.yaml'))
     ]
   end
 end

--- a/app/paths.rb
+++ b/app/paths.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def allsearch_path(path = '')
+  Pathname.new "#{__dir__}/../#{path}"
+end

--- a/app/services/sample_data_creation_service.rb
+++ b/app/services/sample_data_creation_service.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require_relative '../paths'
+
 class SampleDataCreationService
   def initialize(solr_collection:, filename:, query: 'cats')
     @solr_collection = solr_collection
     @query = query
-    @file_path = Rails.root.join('sample-data', filename)
+    @file_path = allsearch_path("sample-data/#{filename}")
   end
 
   def create

--- a/benchmark/microbenchmarks.rb
+++ b/benchmark/microbenchmarks.rb
@@ -2,10 +2,11 @@
 
 require 'benchmark/ips'
 require_relative '../config/environment'
+require_relative '../app/paths'
 
 Benchmark.ips do |b|
   library_database_repo = RepositoryFactory.library_database
-  csv = CSV.read Rails.root.join('spec/fixtures/files/libjobs/library-databases.csv'), headers: true
+  csv = CSV.read allsearch_path('spec/fixtures/files/libjobs/library-databases.csv'), headers: true
   b.report('LibraryDatabaseRepository#create_from_csv') do
     library_database_repo.create_from_csv csv
     # The deletion should ideally be excluded from the benchmark; it is not what we are trying to measure,

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../app/paths'
+
 # Load the Rails application.
 require_relative 'application'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if allsearch_path('tmp/caching-dev.txt').exist?
     config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -7,7 +7,7 @@ api_key: "<%= ENV['HONEYBADGER_API_KEY'] %>"
 env: "<%= Rails.env %>"
 
 # The absolute path to your project folder.
-root: "<%= Rails.root.to_s %>"
+root: "<%= allsearch_path %>"
 
 # Honeybadger won't report errors in these environments.
 development_environments:

--- a/config/initializers/rom_setup.rb
+++ b/config/initializers/rom_setup.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+require_relative '../../app/paths'
 require_relative '../rom_container'
-require Rails.root.join('lib/middleware/rom')
+require allsearch_path('lib/middleware/rom')
 
 # This initializer is responsible for making a ROM container available
 # to the application

--- a/spec/checks/file_does_not_exist_check_spec.rb
+++ b/spec/checks/file_does_not_exist_check_spec.rb
@@ -5,12 +5,12 @@ require_relative '../../app/checks/file_does_not_exist_check'
 
 RSpec.describe FileDoesNotExistCheck do
   it 'returns success when the file does not exist' do
-    result = described_class.new('some-random-file-1ehjfernfiuernfuinfkjwenfjsnjnfwe').call
+    result = described_class.new(Pathname.new('some-random-file-1ehjfernfiuernfuinfkjwenfjsnjnfwe')).call
     expect(result).to be_success
   end
 
   it 'returns failure when the file does exist' do
-    result = described_class.new(__FILE__).call
+    result = described_class.new(Pathname.new(__FILE__)).call
     expect(result).to be_failure
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,7 +36,7 @@ RSpec.configure do |config|
   # note if you'd prefer not to run each example within a transaction, you
   # should set use_transactional_fixtures to false.
   #
-  config.fixture_paths = Rails.root.join('spec/fixtures').to_s
+  config.fixture_paths = allsearch_path('spec/fixtures').to_s
   config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Health Check' do
 
     it 'returns on overall error when the remove-from-nginx file is present' do
       stub_solr_ping(body: { status: 'OK' }.to_json)
-      remove_from_nginx_path = "#{__dir__}/../../public/remove-from-nginx"
+      remove_from_nginx_path = allsearch_path('public/remove-from-nginx')
       File.open remove_from_nginx_path, 'w'
 
       get '/health.json'

--- a/spec/services/sample_data_creation_service_spec.rb
+++ b/spec/services/sample_data_creation_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SampleDataCreationService do
     end
 
     after do
-      test_file = Rails.root.join('sample-data/test.json')
+      test_file = allsearch_path('sample-data/test.json')
       test_file.delete if test_file.file?
     end
 
@@ -19,7 +19,7 @@ RSpec.describe SampleDataCreationService do
                                     query: 'cats',
                                     filename: 'test.json')
       creator.create
-      created_data = JSON.parse(Rails.root.join('sample-data/test.json').read)
+      created_data = JSON.parse(allsearch_path('sample-data/test.json').read)
       expect(created_data.count).to eq(3)
       expect(created_data.first.keys).not_to include('hashed_id_ssi')
       expect(created_data.first.keys).not_to include('_version_')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ if ENV['CI'] || ENV['COVERAGE']
 end
 
 require 'webmock/rspec'
+require_relative '../app/paths'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -6,7 +6,7 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.openapi_root = Rails.root.join('swagger').to_s
+  config.openapi_root = allsearch_path('swagger').to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will


### PR DESCRIPTION
We are moving away from Rails, so we can no longer rely on `Rails.root` and `Rails.root.join`.  Instead, this PR introduces a new method `allsearch_path` which fulfills the same needs.