### PR TITLE
Replace uses of Rails config_for with our own class

### DIFF
--- a/app/environment.rb
+++ b/app/environment.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'paths'
+
+class Environment
+  def initialize(vars = ENV)
+    @vars = vars
+  end
+
+  def name
+    vars['RAILS_ENV'] || 'development'
+  end
+
+  def config(config_filename)
+    config_filepath = allsearch_path("config/#{config_filename}.yml")
+    YAML.safe_load(ERB.new(config_filepath.read).result, aliases: true, symbolize_names: true)[name.to_sym]
+  end
+
+  private
+
+  attr_reader :vars
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require_relative '../environment'
 
 # This class is responsible for querying the Summon API, aka "Articles+"
 class Article
@@ -13,7 +14,7 @@ class Article
 
   def initialize(query_terms:)
     @query_terms = query_terms
-    summon_config = Rails.application.config_for(:allsearch)[:summon]
+    summon_config = Environment.new.config(:allsearch)[:summon]
     @service = Summon::Service.new(access_id: summon_config[:access_id],
                                    secret_key: summon_config[:secret_key])
   end

--- a/app/models/catalog_document.rb
+++ b/app/models/catalog_document.rb
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
+require_relative '../environment'
+
 # This class is responsible for getting relevant
 # metadata from the Catalog's JSON
 # The document is a Hash
 class CatalogDocument < Document
   include SolrDocument
 
+  def initialize(document:, doc_keys:, environment: Environment.new)
+    super(document:, doc_keys:)
+    @environment = environment
+  end
+
   private
+
+  attr_reader :environment
 
   include Holdings
 

--- a/app/models/concerns/solr.rb
+++ b/app/models/concerns/solr.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../environment'
+
 # This module helps classes communicate with Solr APIs
 module Solr
   def solr_service_response
@@ -40,15 +42,19 @@ module Solr
     end
   end
 
+  def allsearch_config
+    @allsearch_config ||= Environment.new.config(:allsearch)
+  end
+
   def solr_collection
-    Rails.application.config_for(:allsearch)[service][:solr][:collection]
+    allsearch_config[service.to_sym][:solr][:collection]
   end
 
   def solr_config
-    Rails.application.config_for(:allsearch)[service][:solr]
+    allsearch_config[service.to_sym][:solr]
   end
 
   def service_subdomain
-    Rails.application.config_for(:allsearch)[service][:subdomain]
+    allsearch_config[service.to_sym][:subdomain]
   end
 end

--- a/app/models/concerns/solr_document.rb
+++ b/app/models/concerns/solr_document.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../environment'
+
 # This module helps classes create documents based on Solr
 module SolrDocument
   private
@@ -13,6 +15,6 @@ module SolrDocument
   end
 
   def service_subdomain
-    Rails.application.config_for(:allsearch)[service][:subdomain]
+    environment.config(:allsearch)[service.to_sym][:subdomain]
   end
 end

--- a/app/models/dpul_document.rb
+++ b/app/models/dpul_document.rb
@@ -5,7 +5,14 @@
 class DpulDocument < Document
   include SolrDocument
 
+  def initialize(document:, doc_keys:, environment: Environment.new)
+    super(document:, doc_keys:)
+    @environment = environment
+  end
+
   private
+
+  attr_reader :environment
 
   def service
     'dpul'

--- a/app/models/findingaids_document.rb
+++ b/app/models/findingaids_document.rb
@@ -5,7 +5,14 @@
 class FindingaidsDocument < Document
   include SolrDocument
 
+  def initialize(document:, doc_keys:, environment: Environment.new)
+    super(document:, doc_keys:)
+    @environment = environment
+  end
+
   private
+
+  attr_reader :environment
 
   def service
     'findingaids'

--- a/app/models/library_website.rb
+++ b/app/models/library_website.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'flipper'
+require_relative '../environment'
 
 class LibraryWebsite
   include Parsed
@@ -9,7 +10,7 @@ class LibraryWebsite
 
   def initialize(query_terms:)
     @query_terms = query_terms
-    @website_config = Rails.application.config_for(:allsearch)[:library_website]
+    @website_config = Environment.new.config(:allsearch)[:library_website]
   end
 
   def self.library_website_host
@@ -22,7 +23,7 @@ class LibraryWebsite
   end
 
   def self.website_config
-    @website_config ||= Rails.application.config_for(:allsearch)[:library_website]
+    @website_config ||= Environment.new.config(:allsearch)[:library_website]
   end
 
   def documents

--- a/app/models/pulmap_document.rb
+++ b/app/models/pulmap_document.rb
@@ -5,7 +5,14 @@
 class PulmapDocument < Document
   include SolrDocument
 
+  def initialize(document:, doc_keys:, environment: Environment.new)
+    super(document:, doc_keys:)
+    @environment = environment
+  end
+
   private
+
+  attr_reader :environment
 
   def service
     'pulmap'

--- a/app/services/oauth_service.rb
+++ b/app/services/oauth_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../environment'
+
 # This class is responsible for communicating with an
 # OAuth server to get new access tokens
 class OAuthService
@@ -43,6 +45,6 @@ class OAuthService
   end
 
   def configuration
-    @configuration ||= Rails.application.config_for(:allsearch)[service]
+    @configuration ||= Environment.new.config(:allsearch)[service.to_sym]
   end
 end

--- a/spec/models/catalog_document_spec.rb
+++ b/spec/models/catalog_document_spec.rb
@@ -46,12 +46,9 @@ RSpec.describe CatalogDocument do
   end
 
   context 'when on a non-production environment' do
-    before do
-      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('staging'))
-    end
-
     it 'links to the record url associated with the solr collection' do
-      document = described_class.new(document: {}, doc_keys: [])
+      document = described_class.new(document: {}, doc_keys: [],
+                                     environment: Environment.new({ 'RAILS_ENV' => 'staging' }))
       expect(document.send(:url)).to eq('https://catalog-staging.princeton.edu/catalog/')
     end
   end

--- a/spec/models/catalog_spec.rb
+++ b/spec/models/catalog_spec.rb
@@ -19,7 +19,13 @@ RSpec.describe Catalog do
 
     context 'when on a non-production environment' do
       before do
-        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('staging'))
+        allow(ENV).to receive(:[]).and_wrap_original do |m, *args|
+          if args.first == 'RAILS_ENV'
+            'staging'
+          else
+            m.call(*args)
+          end
+        end
         stub_request(:get, 'http://lib-solr8d-staging.princeton.edu:8983/solr/catalog-staging/select?facet=false&fl=id,title_display,author_display,pub_created_display,format,holdings_1display,electronic_portfolio_s,electronic_access_1display&q=rubix&rows=3&sort=score%20desc,%20pub_date_start_sort%20desc,%20title_sort%20asc')
           .to_return(status: 200, body: file_fixture('solr/catalog/rubix.json'))
       end

--- a/spec/models/dpul_document_spec.rb
+++ b/spec/models/dpul_document_spec.rb
@@ -18,12 +18,9 @@ RSpec.describe DpulDocument do
   end
 
   context 'when on a non-production environment' do
-    before do
-      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('staging'))
-    end
-
     it 'links to the record url associated with the solr collection' do
-      document = described_class.new(document: {}, doc_keys: [])
+      document = described_class.new(document: {}, doc_keys: [],
+                                     environment: Environment.new({ 'RAILS_ENV' => 'staging' }))
       expect(document.send(:url)).to eq('https://dpul-staging.princeton.edu/catalog/')
     end
   end


### PR DESCRIPTION
As well as moving away from Rails' API, this abstraction should hopefully help us in the future if we want to move away from calling our enviornment variable 'RAILS_ENV'.