### PR TITLE
Replace rswag with our own OpenAPI handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,14 @@ RSpec/EmptyExampleGroup:
   Exclude:
     - 'spec/requests/api/*'
 
+RSpec/RepeatedDescription:
+  Exclude:
+    - 'spec/requests/api/*'
+
+RSpec/RepeatedExample:
+  Exclude:
+    - 'spec/requests/api/*'
+
 RSpec/SpecFilePathFormat:
   Exclude:
     - 'spec/models/oauth_token_cache_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :development, :test do
   gem 'reek'
   gem 'rspec_junit_formatter', require: false
   gem 'rspec-rails'
-  gem 'rswag-specs'
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,9 +150,6 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.16.0)
-    json-schema (5.1.1)
-      addressable (~> 2.8)
-      bigdecimal (~> 3.1)
     language_server-protocol (3.17.0.5)
     libdatadog (18.1.0.1.0)
     libdatadog (18.1.0.1.0-x86_64-linux)
@@ -291,11 +288,6 @@ GEM
     rspec-support (3.13.4)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rswag-specs (2.16.0)
-      activesupport (>= 5.2, < 8.1)
-      json-schema (>= 2.2, < 6.0)
-      railties (>= 5.2, < 8.1)
-      rspec-core (>= 2.14)
     rubocop (1.81.7)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -410,7 +402,6 @@ DEPENDENCIES
   rom-sql
   rspec-rails
   rspec_junit_formatter
-  rswag-specs
   rubocop-rails
   rubocop-rspec
   sequel-activerecord_connection

--- a/README.md
+++ b/README.md
@@ -77,10 +77,8 @@ Documentation lives in `https://allsearch-api.princeton.edu/api-docs`
 
 To update the api documentation for a service:
 * create a spec in: `spec/requests/api/`
-   * `./bin/rails generate rspec:swagger CatalogController --spec_path requests/api/`
-   *  Do the necessary changes to create the swagger doc based on the spec.
 * Generate the docs by running:
-    * `bundle exec rake rswag:specs:swaggerize`.
+    * `bundle exec rake openapi:generate`.
     * This will generate the file `swagger/v1/swagger.yaml`.
     * Please make sure to commit it.
 * Visit the documentation:

--- a/lib/tasks/openapi.rake
+++ b/lib/tasks/openapi.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :openapi do
+  desc 'Re-generate the OpenAPI/swagger spec'
+  task generate: :environment do
+    system 'GENERATE_OPEN_API_SPECS=true bundle exec rspec'
+  end
+end

--- a/spec/requests/api/art_museum_spec.rb
+++ b/spec/requests/api/art_museum_spec.rb
@@ -7,30 +7,21 @@ RSpec.describe 'art_museum' do
     stub_art_museum(query: 'cats', fixture: 'art_museum/cats.json')
   end
 
-  path '/search/artmuseum' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query the Art Museum'
-    get('/search/artmuseum?query={query}') do
-      tags 'Art Museum'
-      operationId 'searchArtmuseum'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches the Art Museum using a query term'
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
+  openapi_path '/search/artmuseum' do
+    openapi_parameter 'name' => 'query', 'in' => 'query',
+                      'description' => 'A string to query the Art Museum',
+                      'schema' => { 'type' => 'string' }
+    openapi_get({
+                  'summary' => '/search/artmuseum?query={query}',
+                  'tags' => ['Art Museum'],
+                  'operationId' => 'searchArtmuseum',
+                  'description' => 'Searches the Art Museum using a query term'
+                }) do
+      openapi_response('200', 'successful', { query: 'cats' })
 
-      response(200, 'successful') do
-        let(:query) { 'cats' }
-        run_test!
-      end
-
-      response(400, 'with an empty search query') do
-        let(:query) { '' }
-        run_test! do |response|
+      openapi_response('400', 'with an empty search query', { query: '' }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',
@@ -39,9 +30,9 @@ RSpec.describe 'art_museum' do
         end
       end
 
-      response(400, 'with a search query that only contains whitespace') do
-        let(:query) { "\t  \n " }
-        run_test! do |response|
+      openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',

--- a/spec/requests/api/banner_spec.rb
+++ b/spec/requests/api/banner_spec.rb
@@ -3,23 +3,14 @@
 require 'swagger_helper'
 
 RSpec.describe 'banner' do
-  path '/banner' do
-    get('show banner') do
-      tags 'Banner'
-      operationId 'displayBanner'
-      produces 'application/json'
-      description 'Displays the current settings for the banner'
-      response(200, 'successful') do
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-
-        run_test!
-      end
+  openapi_path '/banner' do
+    openapi_get({
+                  'summary' => '/banner',
+                  'tags' => ['Banner'],
+                  'operationId' => 'displayBanner',
+                  'description' => 'Displays the current settings for the banner'
+                }) do
+      openapi_response('200', 'successful')
     end
   end
 end

--- a/spec/requests/api/best_bet_spec.rb
+++ b/spec/requests/api/best_bet_spec.rb
@@ -3,31 +3,20 @@
 require 'swagger_helper'
 
 RSpec.describe 'best_bet' do
-  path '/search/best-bet' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query the Best Bets'
-    get('/search/best-bet?query={query}') do
-      tags 'Best Bets'
-      operationId 'searchBestBet'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches the Best Bets using a query term'
+  openapi_path '/search/best-bet' do
+    openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query the Best Bets',
+                      'schema' => { 'type' => 'string' }
+    openapi_get({
+                  'summary' => '/search/best-bet?query={query}',
+                  'tags' => ['Best Bets'],
+                  'operationId' => 'searchBestBet',
+                  'description' => 'Searches the Best Bets using a query term'
+                }) do
+      openapi_response('200', 'successful', { query: 'cats' })
 
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
-
-      response(200, 'successful') do
-        let(:query) { 'cats' }
-        run_test!
-      end
-
-      response(400, 'with an empty search query') do
-        let(:query) { '' }
-        run_test! do |response|
+      openapi_response('400', 'with an empty search query', { query: '' }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',
@@ -36,9 +25,9 @@ RSpec.describe 'best_bet' do
         end
       end
 
-      response(400, 'with a search query that only contains whitespace') do
-        let(:query) { "\t  \n " }
-        run_test! do |response|
+      openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',

--- a/spec/requests/api/dpul_spec.rb
+++ b/spec/requests/api/dpul_spec.rb
@@ -8,32 +8,21 @@ RSpec.describe 'dpul' do
       .to_return(status: 200, body: file_fixture('solr/dpul/cats.json'))
   end
 
-  path '/search/dpul' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query Dpul'
+  openapi_path '/search/dpul' do
+    openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query Dpul',
+                      'schema' => { 'type' => 'string' }
 
-    get('/search/dpul?query={query}') do
-      tags 'Dpul'
-      operationId 'searchDpul'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches Dpul using a query term'
+    openapi_get({
+                  'summary' => '/search/dpul?query={query}',
+                  'tags' => ['Dpul'],
+                  'operationId' => 'searchDpul',
+                  'description' => 'Searches Dpul using a query term'
+                }) do
+      openapi_response('200', 'successful', { query: 'cats' })
 
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
-
-      response(200, 'successful') do
-        let(:query) { 'cats' }
-        run_test!
-      end
-
-      response(400, 'with an empty search query') do
-        let(:query) { '' }
-        run_test! do |response|
+      openapi_response('400', 'with an empty search query', { query: '' }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',
@@ -42,9 +31,9 @@ RSpec.describe 'dpul' do
         end
       end
 
-      response(400, 'with a search query that only contains whitespace') do
-        let(:query) { "\t  \n " }
-        run_test! do |response|
+      openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',

--- a/spec/requests/api/findingaids_spec.rb
+++ b/spec/requests/api/findingaids_spec.rb
@@ -8,32 +8,22 @@ RSpec.describe 'findingaids' do
       .to_return(status: 200, body: file_fixture('solr/findingaids/cats.json'))
   end
 
-  path '/search/findingaids' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query Findingaids'
+  openapi_path '/search/findingaids' do
+    openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query Findingaids',
+                      'schema' => { 'type' => 'string' }
 
-    get('/search/findingaids?query={query}') do
-      tags 'Findingaids'
-      operationId 'searchFindingaids'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches Findingaids using a query term'
+    openapi_get({
+                  'summary' => '/search/findingaids?query={query}',
+                  'tags' => ['Findingaids'],
+                  'operationId' => 'searchFindingaids',
+                  'description' => 'Searches Findingaids using a query term'
 
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
+                }) do
+      openapi_response('200', 'successful', { query: 'cats' })
 
-      response(200, 'successful') do
-        let(:query) { 'cats' }
-        run_test!
-      end
-
-      response(400, 'with an empty search query') do
-        let(:query) { '' }
-        run_test! do |response|
+      openapi_response('400', 'with an empty search query', { query: '' }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',
@@ -42,9 +32,9 @@ RSpec.describe 'findingaids' do
         end
       end
 
-      response(400, 'with a search query that only contains whitespace') do
-        let(:query) { "\t  \n " }
-        run_test! do |response|
+      openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',

--- a/spec/requests/api/libanswers_spec.rb
+++ b/spec/requests/api/libanswers_spec.rb
@@ -3,36 +3,26 @@
 require 'swagger_helper'
 
 RSpec.describe 'libanswers' do
-  path '/search/libanswers' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query Libanswers'
-    get('/search/libanswers?query={query}') do
-      tags 'Libanswers'
-      operationId 'searchLibanswers'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches the Libanswers FAQs using a query term'
+  describe 'with valid authentication' do
+    before do
+      stub_libanswers(query: 'printer', fixture: 'libanswers/printer.json')
+    end
 
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
+    openapi_path '/search/libanswers' do
+      openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query Libanswers',
+                        'schema' => { 'type' => 'string' }
+      openapi_get({
+                    'summary' => '/search/libanswers?query={query}',
+                    'tags' => ['Libanswers'],
+                    'operationId' => 'searchLibanswers',
+                    'description' => 'Searches the Libanswers FAQs using a query term'
+                  }) do
+        openapi_response('200', 'successful', { query: 'printer' })
 
-      describe 'with valid authentication' do
-        before do
-          stub_libanswers(query: 'printer', fixture: 'libanswers/printer.json')
-        end
-
-        response(200, 'successful') do
-          let(:query) { 'printer' }
-          run_test!
-        end
-
-        response(400, 'with a search query that only contains whitespace') do
-          let(:query) { "\t  \n " }
-          run_test! do |response|
+        openapi_response('400', 'with a search query that only contains whitespace',
+                         { query: "\t  \n " }) do |url|
+          it 'gives the empty query message' do
+            get url
             data = JSON.parse(response.body, symbolize_names: true)
             expect(data[:error]).to eq({
                                          problem: 'QUERY_IS_EMPTY',
@@ -41,22 +31,34 @@ RSpec.describe 'libanswers' do
           end
         end
       end
+    end
+    describe "when the system can't authenticate with libanswers" do
+      before do
+        stub_request(:post, 'https://faq.library.princeton.edu/api/1.1/oauth/token')
+          .to_return(status: 400, body: '{"error":"The client credentials are invalid"}')
+        allow(Honeybadger).to receive(:notify)
+      end
 
-      response(500, "when the system can't authenticate with libanswers") do
-        let(:query) { 'some_query' }
-        before do
-          stub_request(:post, 'https://faq.library.princeton.edu/api/1.1/oauth/token')
-            .to_return(status: 400, body: '{"error":"The client credentials are invalid"}')
-          allow(Honeybadger).to receive(:notify)
-        end
-
-        run_test! do |response|
-          data = JSON.parse(response.body, symbolize_names: true)
-          expect(data[:error]).to eq({
-                                       problem: 'UPSTREAM_ERROR',
-                                       message: 'Could not generate a valid authentication token with upstream service.'
-                                     })
-          expect(Honeybadger).to have_received(:notify)
+      openapi_path '/search/libanswers' do
+        openapi_get({
+                      'summary' => '/search/libanswers?query={query}',
+                      'tags' => ['Libanswers'],
+                      'operationId' => 'searchLibanswers',
+                      'description' => 'Searches the Libanswers FAQs using a query term'
+                    }) do
+          openapi_response('500', "when the system can't authenticate with libanswers",
+                           { query: 'some query' }) do |url|
+            it 'gives a relevant error message' do
+              get url
+              data = JSON.parse(response.body, symbolize_names: true)
+              expect(data[:error])
+                .to eq({
+                         problem: 'UPSTREAM_ERROR',
+                         message: 'Could not generate a valid authentication token with upstream service.'
+                       })
+              expect(Honeybadger).to have_received(:notify)
+            end
+          end
         end
       end
     end

--- a/spec/requests/api/libguides_spec.rb
+++ b/spec/requests/api/libguides_spec.rb
@@ -3,45 +3,34 @@
 require 'swagger_helper'
 
 RSpec.describe 'libguides' do
-  path '/search/libguides' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query Libguides'
-    get('/search/libguides?query={query}') do
-      tags 'Libguides'
-      operationId 'searchLibguides'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches the Libguides research guides using a query term'
-
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
+  describe 'with valid authentication' do
+    before do
+      stub_request(:post, 'https://lgapi-us.libapps.com/1.2/oauth/token')
+        .with(body: 'client_id=ABC&client_secret=12345&grant_type=client_credentials')
+        .to_return(status: 200, body: file_fixture('libanswers/oauth_token.json'))
+      stub_request(:get, 'https://lgapi-us.libapps.com/1.2/guides?expand=owner,subjects,tags&search_terms=Asian%20American%20Studies&sort_by=relevance&status=1')
+        .with(
+          headers: {
+            'Authorization' => 'Bearer abcdef1234567890abcdef1234567890abcdef12'
           }
-        }
-      end
+        )
+        .to_return(status: 200, body: file_fixture('libguides/asian_american_studies.json'))
+    end
 
-      describe 'with valid authentication' do
-        before do
-          stub_request(:post, 'https://lgapi-us.libapps.com/1.2/oauth/token')
-            .with(body: 'client_id=ABC&client_secret=12345&grant_type=client_credentials')
-            .to_return(status: 200, body: file_fixture('libanswers/oauth_token.json'))
-          stub_request(:get, 'https://lgapi-us.libapps.com/1.2/guides?expand=owner,subjects,tags&search_terms=Asian%20American%20Studies&sort_by=relevance&status=1')
-            .with(
-              headers: {
-                'Authorization' => 'Bearer abcdef1234567890abcdef1234567890abcdef12'
-              }
-            )
-            .to_return(status: 200, body: file_fixture('libguides/asian_american_studies.json'))
-        end
+    openapi_path '/search/libguides' do
+      openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query Libguides',
+                        'schema' => { 'type' => 'string' }
+      openapi_get({
+                    'summary' => '/search/libguides?query={query}',
+                    'tags' => ['Libguides'],
+                    'operationId' => 'searchLibguides',
+                    'description' => 'Searches the Libguides research guides using a query term'
+                  }) do
+        openapi_response('200', 'successful', { query: 'Asian American Studies' })
 
-        response(200, 'successful') do
-          let(:query) { 'Asian American Studies' }
-          run_test!
-        end
-
-        response(400, 'with a search query that only contains whitespace') do
-          let(:query) { "\t  \n " }
-          run_test! do |response|
+        openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+          it 'gives the empty query message' do
+            get url
             data = JSON.parse(response.body, symbolize_names: true)
             expect(data[:error]).to eq({
                                          problem: 'QUERY_IS_EMPTY',
@@ -50,22 +39,34 @@ RSpec.describe 'libguides' do
           end
         end
       end
+    end
+  end
 
-      response(500, "when the system can't authenticate with libguides") do
-        let(:query) { 'some_query' }
-        before do
-          stub_request(:post, 'https://lgapi-us.libapps.com/1.2/oauth/token')
-            .to_return(status: 400, body: '{"error":"The client credentials are invalid"}')
-          allow(Honeybadger).to receive(:notify)
-        end
+  describe "when the system can't authenticate with libguides" do
+    before do
+      stub_request(:post, 'https://lgapi-us.libapps.com/1.2/oauth/token')
+        .to_return(status: 400, body: '{"error":"The client credentials are invalid"}')
+      allow(Honeybadger).to receive(:notify)
+    end
 
-        run_test! do |response|
-          data = JSON.parse(response.body, symbolize_names: true)
-          expect(data[:error]).to eq({
-                                       problem: 'UPSTREAM_ERROR',
-                                       message: 'Could not generate a valid authentication token with upstream service.'
-                                     })
-          expect(Honeybadger).to have_received(:notify)
+    openapi_path '/search/libguides' do
+      openapi_get({
+                    'summary' => '/search/libguides?query={query}',
+                    'tags' => ['Libguides'],
+                    'operationId' => 'searchLibguides',
+                    'description' => 'Searches the Libguides research guides using a query term'
+                  }) do
+        openapi_response('500', "when the system can't authenticate with libguides", { query: 'some_query' }) do |url|
+          it 'gives a relevant error message' do
+            get url
+            data = JSON.parse(response.body, symbolize_names: true)
+            expect(data[:error])
+              .to eq({
+                       problem: 'UPSTREAM_ERROR',
+                       message: 'Could not generate a valid authentication token with upstream service.'
+                     })
+            expect(Honeybadger).to have_received(:notify)
+          end
         end
       end
     end

--- a/spec/requests/api/library_database_spec.rb
+++ b/spec/requests/api/library_database_spec.rb
@@ -3,32 +3,21 @@
 require 'swagger_helper'
 
 RSpec.describe 'library_database' do
-  path '/search/database' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query the Library Databases'
+  openapi_path '/search/database' do
+    openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query the Library Databases',
+                      'schema' => { 'type' => 'string' }
 
-    get('search/database?query={query}') do
-      tags 'Library Databases'
-      operationId 'searchDatabase'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches for relevant Library Databases using a query term'
+    openapi_get({
+                  'summary' => '/search/database?query={query}',
+                  'tags' => ['Library Databases'],
+                  'operationId' => 'searchDatabase',
+                  'description' => 'Searches for relevant Library Databases using a query term'
+                }) do
+      openapi_response('200', 'successful', { query: 'oxford music' })
 
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
-
-      response(200, 'successful') do
-        let(:query) { 'oxford music' }
-        run_test!
-      end
-
-      response(400, 'with an empty search query') do
-        let(:query) { '' }
-        run_test! do |response|
+      openapi_response('400', 'with an empty search query', { query: '' }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',
@@ -37,9 +26,9 @@ RSpec.describe 'library_database' do
         end
       end
 
-      response(400, 'with a search query that only contains whitespace') do
-        let(:query) { "\t  \n " }
-        run_test! do |response|
+      openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',

--- a/spec/requests/api/library_staff_spec.rb
+++ b/spec/requests/api/library_staff_spec.rb
@@ -3,32 +3,21 @@
 require 'swagger_helper'
 
 RSpec.describe 'library_staff' do
-  path '/search/staff' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query the Library Staff'
+  openapi_path '/search/staff' do
+    openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query the Library Staff',
+                      'schema' => { 'type' => 'string' }
 
-    get('search/staff?query={query}') do
-      tags 'Library Staff'
-      operationId 'searchStaff'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches for relevant Library Staff using a query term'
+    openapi_get({
+                  'summary' => '/search/staff?query={query}',
+                  'tags' => ['Library Staff'],
+                  'operationId' => 'searchStaff',
+                  'description' => 'Searches for relevant Library Staff using a query term'
+                }) do
+      openapi_response('200', 'successful', { query: 'Lucy' })
 
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
-
-      response(200, 'successful') do
-        let(:query) { 'Lucy' }
-        run_test!
-      end
-
-      response(400, 'with an empty search query') do
-        let(:query) { '' }
-        run_test! do |response|
+      openapi_response('400', 'with an empty search query', { query: '' }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',
@@ -37,9 +26,9 @@ RSpec.describe 'library_staff' do
         end
       end
 
-      response(400, 'with a search query that only contains whitespace') do
-        let(:query) { "\t  \n " }
-        run_test! do |response|
+      openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',

--- a/spec/requests/api/pulmap_spec.rb
+++ b/spec/requests/api/pulmap_spec.rb
@@ -8,32 +8,21 @@ RSpec.describe 'pulmap' do
       .to_return(status: 200, body: file_fixture('solr/pulmap/scribner.json'))
   end
 
-  path '/search/pulmap' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query Pulmap'
+  openapi_path '/search/pulmap' do
+    openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query Pulmap',
+                      'schema' => { 'type' => 'string' }
 
-    get('/search/pulmap?query={query}') do
-      tags 'Pulmap'
-      operationId 'searchPulmap'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches Pulmap using a query term'
+    openapi_get({
+                  'summary' => '/search/pulmap?query={query}',
+                  'tags' => ['Pulmap'],
+                  'operationId' => 'searchPulmap',
+                  'description' => 'Searches Pulmap using a query term'
+                }) do
+      openapi_response('200', 'successful', { query: 'scribner' })
 
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
-
-      response(200, 'successful') do
-        let(:query) { 'scribner' }
-        run_test!
-      end
-
-      response(400, 'with an empty search query') do
-        let(:query) { '' }
-        run_test! do |response|
+      openapi_response('400', 'with an empty search query', { query: '' }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',
@@ -42,9 +31,9 @@ RSpec.describe 'pulmap' do
         end
       end
 
-      response(400, 'with a search query that only contains whitespace') do
-        let(:query) { "\t  \n " }
-        run_test! do |response|
+      openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',

--- a/spec/requests/api/website_spec.rb
+++ b/spec/requests/api/website_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'swagger_helper'
-require 'rails_helper'
 
 RSpec.describe 'website' do
   let(:url) do
@@ -15,31 +14,20 @@ RSpec.describe 'website' do
       .to_return(status: 401)
   end
 
-  path '/search/website' do
-    parameter name: 'query', in: :query, type: :string, description: 'A string to query the Library Website'
-    get('/search/article?query={query}') do
-      tags 'Library Website'
-      operationId 'searchWebsite'
-      consumes 'application/json'
-      produces 'application/json'
-      description 'Searches the Library Website using a query term.'
+  openapi_path '/search/website' do
+    openapi_parameter 'name' => 'query', 'in' => 'query', 'description' => 'A string to query the Library Website',
+                      'schema' => { 'type' => 'string' }
+    openapi_get({
+                  'summary' => '/search/website?query={query}',
+                  'tags' => ['Library Website'],
+                  'operationId' => 'searchWebsite',
+                  'description' => 'Searches the Library Website using a query term.'
+                }) do
+      openapi_response('200', 'successful', { query: 'firestone' })
 
-      after do |example|
-        example.metadata[:response][:content] = {
-          'application/json' => {
-            example: JSON.parse(response.body, symbolize_names: true)
-          }
-        }
-      end
-
-      response(200, 'successful') do
-        let(:query) { 'firestone' }
-        run_test!
-      end
-
-      response(400, 'with an empty search query') do
-        let(:query) { '' }
-        run_test! do |response|
+      openapi_response('400', 'with an empty search query', { query: '' }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',
@@ -48,9 +36,9 @@ RSpec.describe 'website' do
         end
       end
 
-      response(400, 'with a search query that only contains whitespace') do
-        let(:query) { "\t  \n " }
-        run_test! do |response|
+      openapi_response('400', 'with a search query that only contains whitespace', { query: "\t  \n " }) do |url|
+        it 'gives the empty query message' do
+          get url
           data = JSON.parse(response.body, symbolize_names: true)
           expect(data[:error]).to eq({
                                        problem: 'QUERY_IS_EMPTY',

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -2,41 +2,112 @@
 
 require 'rails_helper'
 
-RSpec.configure do |config|
-  # Specify a root folder where Swagger JSON files are generated
-  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
-  # to ensure that it's configured to serve Swagger from the same folder
-  config.openapi_root = allsearch_path('swagger').to_s
+# This file defines a DSL that both generates an OpenAPI (aka Swagger) Spec for this application
+# and runs RSpec assertions to confirm that the OpenAPI Spec is accurate.  The DSL is extremely
+# influenced by RSwag (https://github.com/rswag/rswag), but this implementation does not rely
+# on Rails and has the openapi_ prefix throughout.
+# To regenerate the OpenAPI spec, run `bundle exec rake openapi:generate` or
+# `GENERATE_OPEN_API_SPECS=true bundle exec rspec`
 
-  # Define one or more Swagger documents and provide global metadata for each one
-  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
-  # be generated at the provided relative path under swagger_root
-  # By default, the operations defined in spec files are added to the first
-  # document below. You can override this behavior by adding a swagger_doc tag to the
-  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.openapi_specs = {
-    'v1/swagger.yaml' => {
-      openapi: '3.0.1',
-      info: {
-        title: 'Allsearch API',
-        description: 'Backend API for allsearch.princeton.edu',
-        version: 'v1'
+class OpenAPISpecGenerator
+  def register_path(path)
+    paths[path] ||= {}
+  end
+
+  def register_parameter(path, parameter)
+    paths[path]['parameters'] ||= []
+    paths[path]['parameters'].push parameter
+  end
+
+  def register_get(path, get)
+    paths[path]['get'] ||= {}
+    paths[path]['get'].merge! get
+  end
+
+  def register_response(path, status_code, response)
+    paths[path]['get']['responses'] ||= {}
+    paths[path]['get']['responses'][status_code] ||= {}
+    paths[path]['get']['responses'][status_code].merge! response
+  end
+
+  def register_content(path, status_code, content)
+    paths[path]['get']['responses'][status_code]['content'] = { 'application/json' => { 'example' => content } }
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def to_yaml
+    {
+      'openapi' => '3.1.1',
+      'info' => {
+        'title' => 'Allsearch API',
+        'description' => 'Backend API for allsearch.princeton.edu',
+        'version' => 'v1'
       },
-      paths: {},
-      servers: [
-        {
-          url: 'https://allsearch-api.princeton.edu'
-        },
-        {
-          url: 'https://allsearch-api-staging.princeton.edu'
-        }
+      'paths' => paths,
+      'servers' => [
+        { 'url' => 'https://allsearch-api.princeton.edu' },
+        { 'url' => 'https://allsearch-api-staging.princeton.edu' }
       ]
-    }
-  }
+    }.to_yaml
+  end
+  # rubocop:enable Metrics/MethodLength
 
-  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
-  # The swagger_docs configuration option has the filename including format in
-  # the key, this may want to be changed to avoid putting yaml in json files.
-  # Defaults to json. Accepts ':json' and ':yaml'.
-  config.openapi_format = :yaml
+  def paths
+    @paths ||= {}
+  end
+end
+OPENAPI_GENERATOR = OpenAPISpecGenerator.new
+
+def openapi_path(url_path, ...)
+  OPENAPI_GENERATOR.register_path(url_path)
+  describe(url_path, ...)
+end
+
+def openapi_parameter(hash)
+  OPENAPI_GENERATOR.register_parameter(metadata[:description], hash)
+end
+
+def openapi_get(hash, ...)
+  begin
+    OPENAPI_GENERATOR.register_get(metadata[:description], hash)
+  rescue StandardError
+    raise 'Could not find the relevant path for this openapi_get. ' \
+          'Please make sure it is nested directly within an openapi_path block'
+  end
+  describe(hash['summary'], ...)
+end
+
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
+def openapi_response(code, description, query_parameters = {})
+  path = metadata[:parent_example_group][:description]
+  begin
+    OPENAPI_GENERATOR.register_response(path, code, { 'description' => description })
+  rescue StandardError
+    raise 'could not add response to OpenAPI documentation, ' \
+          'please make sure that openapi_response is nested immediately within an openapi_get block'
+  end
+  url = query_parameters.reduce(metadata[:description]) do |url_with_placeholders, (placeholder, value)|
+    url_with_placeholders.gsub("{#{placeholder}}", value)
+  end
+  it "returns the expected response code #{code} with query params #{query_parameters}" do
+    get url
+    expect(response.code).to eq code
+    OPENAPI_GENERATOR.register_content(path, code, JSON.parse(response.body))
+  end
+
+  # Run any additional tests specified in the block
+  yield url if block_given?
+end
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/MethodLength
+
+if ENV['GENERATE_OPEN_API_SPECS'] == 'true'
+  RSpec.configure do |config|
+    config.after(:suite) do
+      File.open(allsearch_path('swagger/v1/swagger.yaml'), 'w') do |file|
+        file.puts OPENAPI_GENERATOR.to_yaml
+      end
+    end
+  end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,5 +1,5 @@
 ---
-openapi: 3.0.1
+openapi: 3.1.1
 info:
   title: Allsearch API
   description: Backend API for allsearch.princeton.edu
@@ -213,7 +213,7 @@ paths:
                   message: Could not authenticate to the upstream Summon service
   "/banner":
     get:
-      summary: show banner
+      summary: "/banner"
       tags:
       - Banner
       operationId: displayBanner
@@ -642,7 +642,7 @@ paths:
       schema:
         type: string
     get:
-      summary: search/database?query={query}
+      summary: "/search/database?query={query}"
       tags:
       - Library Databases
       operationId: searchDatabase
@@ -672,7 +672,7 @@ paths:
       schema:
         type: string
     get:
-      summary: search/staff?query={query}
+      summary: "/search/staff?query={query}"
       tags:
       - Library Staff
       operationId: searchStaff
@@ -772,7 +772,7 @@ paths:
       schema:
         type: string
     get:
-      summary: "/search/article?query={query}"
+      summary: "/search/website?query={query}"
       tags:
       - Library Website
       operationId: searchWebsite


### PR DESCRIPTION
This implementation has a lot of similarities with RSwag's API, although methods are renamed with an `openapi_` prefix to distinguish them from methods with the same name in Rack::Test, rspec-rails, and Rails.

This implementation makes more assumptions and is less flexible than RSwag, but hopefully it is a good enough start that we can extend as needed.

As with RSwag, you can run the tests as normal with RSpec.  If you want to refresh the OpenAPI/Swagger spec, you can run RSpec with a specific environment variable (`GENERATE_OPEN_API_SPECS=true`), or, more conveniently, `bundle exec rake openapi:generate`

Closes #405