### PR TITLE
flipper-sequel gem cannot have require: false

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'csv'
 gem 'datadog', '~> 2.0', require: 'datadog/auto_instrument'
 gem 'dogstatsd-ruby'
 gem 'dry-monads'
-gem 'flipper-sequel', require: false
+gem 'flipper-sequel'
 gem 'honeybadger'
 gem 'logstash-event'
 gem 'pg'


### PR DESCRIPTION
Otherwise, flipper does not know how to save whether a feature is on or off, and enabling the banner fails silently.

I introduced this regression in #420