### PR TITLE
Configure prod and staging hosts as well

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module BentoRailsApi
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    config.hosts << 'allsearch-api-staging.princeton.edu'
+    config.hosts << 'allsearch-api.princeton.edu'
     # Rack's mock responses use example.org
     config.hosts << 'example.org'
   end


### PR DESCRIPTION
After merging #453, staging went down.  The application logs said:

```
ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: allsearch-api-staging.princeton.edu
```

Apparently, if you configure one host, you have to configure them all except localhost?