### PR TITLE
Address Flipper warning when running Banner API test

### DIFF
--- a/spec/requests/api/banner_spec.rb
+++ b/spec/requests/api/banner_spec.rb
@@ -3,6 +3,8 @@
 require 'swagger_helper'
 
 RSpec.describe 'banner' do
+  before { Flipper.add :banner }
+
   openapi_path '/banner' do
     openapi_get({
                   'summary' => '/banner',


### PR DESCRIPTION
Prior to this commit, running `bundle exec rspec spec/requests/api/banner_spec.rb` caused the warning message:

```
Could not find feature "banner". Call `Flipper.add("banner")` to create it.
```

We add the desired `Flipper.add` call to resolve the warning.