### PR TITLE
Get smoke tests passing again

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,0 @@
---require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'csv'
 gem 'datadog', '~> 2.0', require: 'datadog/auto_instrument'
 gem 'dogstatsd-ruby'
 gem 'dry-monads'
-gem 'flipper-sequel'
+gem 'flipper-sequel', require: false
 gem 'honeybadger'
 gem 'logstash-event'
 gem 'pg'

--- a/app/controllers/banner_controller.rb
+++ b/app/controllers/banner_controller.rb
@@ -3,7 +3,7 @@
 class BannerController
   def self.call(env)
     banner_repo = RepositoryFactory.new(env['rom']).banner
-    banner_json = banner_repo.banners.first.as_json
+    banner_json = banner_repo.first.as_json
     [200, { 'Content-Type' => 'application/json; charset=utf-8' }, [banner_json]]
   end
 end

--- a/app/repositories/banner_repository.rb
+++ b/app/repositories/banner_repository.rb
@@ -17,6 +17,10 @@ class BannerRepository < ROM::Repository[:banners]
     end
   end
 
+  def first
+    banners.first || create({})
+  end
+
   def delete
     # There should only ever be one, banner, so it is safe to delete them all
     banners.changeset(:delete).commit

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Flipper must be required after a database connection is established
+require_relative '../db_connection'
+begin
+  require 'flipper-sequel'
+rescue Sequel::Error
+  # We may be in a context where the database is not yet available
+  # (e.g. rake servers:start)
+  nil
+end

--- a/smoke_spec/smoke_spec.rb
+++ b/smoke_spec/smoke_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'webmock'
+
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe 'Deployed environment', :staging_test do
   let(:host) { 'allsearch-api-staging.princeton.edu' }


### PR DESCRIPTION
While #448 addressed the immediate problem of being able to turn on/off the banner, it also broke the smoke tests. Requiring flipper-sequel checks for an active database connection, but the container that runs the smoke tests shouldn't need to be connected to a database just to check the health of allsearch-api-staging.

This PR corrects the situation in two ways, either of which should be sufficient:
* Setting `flipper_sequel` back to `require: false` in the Gemfile, and instead adding the needed `require` to a Rails initializer
* Removing the `require spec_helper` instruction in .rspec, which is how flipper was being loaded into the smoke tests in the first place.