### PR TITLE
Only load configs once

### DIFF
--- a/app/checks/check_list.rb
+++ b/app/checks/check_list.rb
@@ -67,7 +67,7 @@ class CheckList
   end
 
   def solr_configs
-    @solr_configs ||= Environment.new.config(:allsearch)
+    @solr_configs ||= ALLSEARCH_CONFIGS[:allsearch]
   end
 
   def db_gateways

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -16,7 +16,7 @@ class Article
 
   def initialize(query_terms:)
     @query_terms = query_terms
-    summon_config = Environment.new.config(:allsearch)[:summon]
+    summon_config = ALLSEARCH_CONFIGS[:allsearch][:summon]
     @service = Summon::Service.new(access_id: summon_config[:access_id],
                                    secret_key: summon_config[:secret_key])
   end

--- a/app/models/catalog.rb
+++ b/app/models/catalog.rb
@@ -5,10 +5,11 @@ class Catalog
   include Parsed
   include Solr
 
-  attr_reader :query_terms, :service, :service_response
+  attr_reader :query_terms, :service, :service_response, :allsearch_config
 
-  def initialize(query_terms:)
+  def initialize(query_terms:, allsearch_config: ALLSEARCH_CONFIGS[:allsearch])
     @query_terms = query_terms
+    @allsearch_config = allsearch_config
     @service = 'catalog'
     @service_response = solr_service_response
   end

--- a/app/models/catalog_document.rb
+++ b/app/models/catalog_document.rb
@@ -10,14 +10,14 @@ class CatalogDocument < Document
   include SolrDocument
   include Dry::Monads[:maybe]
 
-  def initialize(document:, doc_keys:, environment: Environment.new)
+  def initialize(document:, doc_keys:, allsearch_config: ALLSEARCH_CONFIGS[:allsearch])
     super(document:, doc_keys:)
-    @environment = environment
+    @allsearch_config = allsearch_config
   end
 
   private
 
-  attr_reader :environment
+  attr_reader :allsearch_config
 
   include Holdings
 

--- a/app/models/concerns/solr.rb
+++ b/app/models/concerns/solr.rb
@@ -45,10 +45,6 @@ module Solr
     end
   end
 
-  def allsearch_config
-    @allsearch_config ||= Environment.new.config(:allsearch)
-  end
-
   def solr_collection
     allsearch_config[service.to_sym][:solr][:collection]
   end

--- a/app/models/concerns/solr_document.rb
+++ b/app/models/concerns/solr_document.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../environment'
-
 # This module helps classes create documents based on Solr
 module SolrDocument
   private
@@ -15,6 +13,6 @@ module SolrDocument
   end
 
   def service_subdomain
-    environment.config(:allsearch)[service.to_sym][:subdomain]
+    allsearch_config[service.to_sym][:subdomain]
   end
 end

--- a/app/models/dpul.rb
+++ b/app/models/dpul.rb
@@ -5,10 +5,11 @@ class Dpul
   include Parsed
   include Solr
 
-  attr_reader :query_terms, :service, :service_response
+  attr_reader :query_terms, :service, :service_response, :allsearch_config
 
-  def initialize(query_terms:)
+  def initialize(query_terms:, allsearch_config: ALLSEARCH_CONFIGS[:allsearch])
     @query_terms = query_terms
+    @allsearch_config = allsearch_config
     @service = 'dpul'
     @service_response = solr_service_response
   end

--- a/app/models/dpul_document.rb
+++ b/app/models/dpul_document.rb
@@ -5,14 +5,14 @@
 class DpulDocument < Document
   include SolrDocument
 
-  def initialize(document:, doc_keys:, environment: Environment.new)
+  def initialize(document:, doc_keys:, allsearch_config: ALLSEARCH_CONFIGS[:allsearch])
     super(document:, doc_keys:)
-    @environment = environment
+    @allsearch_config = allsearch_config
   end
 
   private
 
-  attr_reader :environment
+  attr_reader :allsearch_config
 
   def service
     'dpul'

--- a/app/models/findingaids.rb
+++ b/app/models/findingaids.rb
@@ -5,10 +5,11 @@ class Findingaids
   include Parsed
   include Solr
 
-  attr_reader :query_terms, :service, :service_response
+  attr_reader :query_terms, :service, :service_response, :allsearch_config
 
-  def initialize(query_terms:)
+  def initialize(query_terms:, allsearch_config: ALLSEARCH_CONFIGS[:allsearch])
     @query_terms = query_terms
+    @allsearch_config = allsearch_config
     @service = 'findingaids'
     @service_response = solr_service_response
   end

--- a/app/models/findingaids_document.rb
+++ b/app/models/findingaids_document.rb
@@ -5,14 +5,14 @@
 class FindingaidsDocument < Document
   include SolrDocument
 
-  def initialize(document:, doc_keys:, environment: Environment.new)
+  def initialize(document:, doc_keys:, allsearch_config: ALLSEARCH_CONFIGS[:allsearch])
     super(document:, doc_keys:)
-    @environment = environment
+    @allsearch_config = allsearch_config
   end
 
   private
 
-  attr_reader :environment
+  attr_reader :allsearch_config
 
   def service
     'findingaids'

--- a/app/models/library_website.rb
+++ b/app/models/library_website.rb
@@ -12,7 +12,7 @@ class LibraryWebsite
 
   def initialize(query_terms:)
     @query_terms = query_terms
-    @website_config = Environment.new.config(:allsearch)[:library_website]
+    @website_config = ALLSEARCH_CONFIGS[:allsearch][:library_website]
   end
 
   def self.library_website_host
@@ -20,7 +20,7 @@ class LibraryWebsite
   end
 
   def self.website_config
-    @website_config ||= Environment.new.config(:allsearch)[:library_website]
+    @website_config ||= ALLSEARCH_CONFIGS[:allsearch][:library_website]
   end
 
   def documents

--- a/app/models/pulmap.rb
+++ b/app/models/pulmap.rb
@@ -5,10 +5,11 @@ class Pulmap
   include Parsed
   include Solr
 
-  attr_reader :query_terms, :service, :service_response
+  attr_reader :query_terms, :service, :service_response, :allsearch_config
 
-  def initialize(query_terms:)
+  def initialize(query_terms:, allsearch_config: ALLSEARCH_CONFIGS[:allsearch])
     @query_terms = query_terms
+    @allsearch_config = allsearch_config
     @service = 'pulmap'
     @service_response = solr_service_response
   end

--- a/app/models/pulmap_document.rb
+++ b/app/models/pulmap_document.rb
@@ -5,14 +5,14 @@
 class PulmapDocument < Document
   include SolrDocument
 
-  def initialize(document:, doc_keys:, environment: Environment.new)
+  def initialize(document:, doc_keys:, allsearch_config: ALLSEARCH_CONFIGS[:allsearch])
     super(document:, doc_keys:)
-    @environment = environment
+    @allsearch_config = allsearch_config
   end
 
   private
 
-  attr_reader :environment
+  attr_reader :allsearch_config
 
   def service
     'pulmap'

--- a/app/services/oauth_service.rb
+++ b/app/services/oauth_service.rb
@@ -45,7 +45,7 @@ class OAuthService
   end
 
   def configuration
-    @configuration ||= Environment.new.config(:allsearch)[service.to_sym]
+    @configuration ||= ALLSEARCH_CONFIGS[:allsearch][service.to_sym]
   end
 
   # :reek:UtilityFunction

--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,9 @@
 
 # This file is used by Rack-based servers to start the application.
 
+require_relative 'app/paths'
 require_relative 'config/environment'
+require allsearch_path 'config/allsearch_configs'
 
 run Rails.application
 Rails.application.load_server

--- a/config/allsearch_configs.rb
+++ b/config/allsearch_configs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative '../app/paths'
+require allsearch_path 'app/environment'
+require 'forwardable'
+
+environment = Environment.new
+
+# Access a config with ALLSEARCH_CONFIGS[:allsearch][:summon]
+ALLSEARCH_CONFIGS = {
+  allsearch: environment.config(:allsearch),
+  database: environment.config(:database)
+}.freeze

--- a/config/db_connection.rb
+++ b/config/db_connection.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
+require_relative 'allsearch_configs'
 require 'erb'
 require 'sequel'
 require 'yaml'
 
 begin
-  path = "#{__dir__}/database.yml"
-  db_config = YAML.safe_load(ERB.new(File.read(path)).result, aliases: true)[Rails.env]
-
-  DB = Sequel.postgres(db_config['database'], user: db_config['username'], password: db_config['password'],
-                                              host: db_config['host'], port: db_config['port'])
+  db_config = ALLSEARCH_CONFIGS[:database]
+  DB = Sequel.postgres(db_config[:database], user: db_config[:username], password: db_config[:password],
+                                             host: db_config[:host], port: db_config[:port])
 rescue StandardError
   nil
 end

--- a/spec/models/catalog_document_spec.rb
+++ b/spec/models/catalog_document_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CatalogDocument do
   context 'when on a non-production environment' do
     it 'links to the record url associated with the solr collection' do
       document = described_class.new(document: {}, doc_keys: [],
-                                     environment: Environment.new({ 'RAILS_ENV' => 'staging' }))
+                                     allsearch_config: { catalog: { subdomain: 'catalog-staging' } })
       expect(document.send(:url)).to eq('https://catalog-staging.princeton.edu/catalog/')
     end
   end

--- a/spec/models/catalog_spec.rb
+++ b/spec/models/catalog_spec.rb
@@ -19,19 +19,15 @@ RSpec.describe Catalog do
 
     context 'when on a non-production environment' do
       before do
-        allow(ENV).to receive(:[]).and_wrap_original do |m, *args|
-          if args.first == 'RAILS_ENV'
-            'staging'
-          else
-            m.call(*args)
-          end
-        end
         stub_request(:get, 'http://lib-solr8d-staging.princeton.edu:8983/solr/catalog-staging/select?facet=false&fl=id,title_display,author_display,pub_created_display,format,holdings_1display,electronic_portfolio_s,electronic_access_1display&q=rubix&rows=3&sort=score%20desc,%20pub_date_start_sort%20desc,%20title_sort%20asc')
           .to_return(status: 200, body: file_fixture('solr/catalog/rubix.json'))
       end
 
       it 'links to the host associated with the solr collection' do
-        catalog = described_class.new(query_terms: 'rubix')
+        catalog = described_class.new(
+          query_terms: 'rubix',
+          allsearch_config: Environment.new({ 'RAILS_ENV' => 'staging' }).config(:allsearch)
+        )
         expect(catalog.more_link.value!.to_s).to eq('https://catalog-staging.princeton.edu/catalog?q=rubix&search_field=all_fields')
       end
     end

--- a/spec/models/dpul_document_spec.rb
+++ b/spec/models/dpul_document_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DpulDocument do
   context 'when on a non-production environment' do
     it 'links to the record url associated with the solr collection' do
       document = described_class.new(document: {}, doc_keys: [],
-                                     environment: Environment.new({ 'RAILS_ENV' => 'staging' }))
+                                     allsearch_config: { dpul: { subdomain: 'dpul-staging' } })
       expect(document.send(:url)).to eq('https://dpul-staging.princeton.edu/catalog/')
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,6 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
 require_relative 'support/database_cleaner'
 
 # Prevent database truncation if the environment is production

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ if ENV['CI'] || ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start 'rails'
 end
+ENV['RAILS_ENV'] ||= 'test'
 
 require 'webmock/rspec'
 require_relative '../app/paths'


### PR DESCRIPTION
Rather than load config files (including YAML parsing) each time we need to consult them, load them once at boot time and store them in a constant.

This took the benchmark/benchmark.sh script execution from 6.01 seconds to 4.73 seconds for me.