### PR TITLE
Don't check the tmp directory with rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'bin/**/*'
     - 'db/**/*'
     - 'solr/**/*'
+    - 'tmp/**/*'
     - 'vendor/bundle/**/*'
 
 Naming/RescuedExceptionsVariableName:


### PR DESCRIPTION
If you have a lot of entries in tmp/cache, rubocop can get really slow!

Before:
```
bundle exec rubocop -a  12.53s user 4.93s system 74% cpu 23.298 total
```

After:
```
bundle exec rubocop -a  2.59s user 1.26s system 147% cpu 2.615 total
```