### PR TITLE
initialize rails before accessing Rails.application.config.rom = container

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require_relative '../config/environment'
 require_relative 'support/database_cleaner'
 
 # Prevent database truncation if the environment is production


### PR DESCRIPTION

Fixes the following error when running bundle exec rspec
error is: undefined method 'rom' for an instance of Rails::Application::Configuration'