### PR TITLE
Fix small regression in more link for staff directory

### DIFF
--- a/app/models/library_staff.rb
+++ b/app/models/library_staff.rb
@@ -17,7 +17,7 @@ class LibraryStaff
     {
       number:,
       records:,
-      more: more_link
+      more: more_link.value_or(nil)
     }.compact.to_json
   end
 

--- a/spec/models/library_staff_spec.rb
+++ b/spec/models/library_staff_spec.rb
@@ -26,5 +26,10 @@ RSpec.describe LibraryStaff do
       expect(our_response[:records]).not_to be_empty
       expect(our_response[:records].first[:other_fields][:first_name]).to eq('Brutus Ét tu')
     end
+
+    it 'has a valid more link in the JSON response' do
+      our_response = JSON.parse(staff_service.our_response, symbolize_names: true)
+      expect(our_response[:more]).to eq 'https://library.princeton.edu/about/staff-directory?combine=%C3%89t+tu'
+    end
   end
 end


### PR DESCRIPTION
The Some() just needed to be unwrapped.  Prior to this commit, the JSON included:

```
more: {value: 'http://library.princeton...
```

And as a result, the more link the interface did not work.

With this patch, the JSON is as expected:

```
more: 'http://library.princeton...
```