### PR TITLE
Don't send the same request to Summon three times

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,7 +22,7 @@ class Article
 
   # For documentation on query parameters, see https://developers.exlibrisgroup.com/summon/apis/SearchAPI/Query/Parameters/
   def service_response
-    service.search(
+    @service_response ||= service.search(
       's.q': query_terms, # Lucene-style queries
       's.fvf': 'ContentType,Newspaper Article,true', # Excludes newspaper articles
       's.ho': 't', # Princeton holdings only

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -35,4 +35,9 @@ RSpec.describe Article do
 
     expect(facet_value_filter.value).to eq('Newspaper Article')
   end
+
+  it 'does not make excessive queries when compiling our response' do
+    article.our_response
+    expect(WebMock).to have_requested(:get, %r{http://api\.summon\.serialssolutions\.com.*}).times(1)
+  end
 end


### PR DESCRIPTION
Prior to this commit, we sent the same request three times for each search: once for the documents, once for the more_link, and once for the record count.  Memoizing the results fixes this.

With some simple experimentations locally, this took the response time of our article search from a median of ~1 second to ~0.4 seconds.