### PR TITLE
Re-open the semantic logger after passenger forks the process

### DIFF
--- a/init/logger.rb
+++ b/init/logger.rb
@@ -12,3 +12,9 @@ def new_logger(environment = CURRENT_ENVIRONMENT)
 end
 
 ALLSEARCH_LOGGER = new_logger
+
+if defined?(PhusionPassenger)
+  PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    SemanticLogger.reopen if forked
+  end
+end


### PR DESCRIPTION
See [the semantic logger documentation](https://github.com/reidmorrison/semantic_logger/blob/bae745b222e99170487575d491e4592c08cc856f/docs/forking.md#auto-detected-frameworks)

Without this addition, the logger did not log any requests in staging or production.  It also did not log any requests when we ran the application locally with passenger.