### PR TITLE
Correct typo in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,7 @@ RSpec/EmptyExampleGroup:
   Exclude:
     - 'spec/requests/api/*'
 
-RSepc/NestedGroups:
+RSpec/NestedGroups:
   Exclude:
     - 'spec/relations/best_bet_relation_spec.rb'
 


### PR DESCRIPTION
This fixes the warning:

```
.rubocop.yml: RSepc/NestedGroups has the wrong namespace - replace it with RSpec/NestedGroups
```