### PR TITLE
Replace rails_helper with rack_helper for test support

### DIFF
--- a/init/environment.rb
+++ b/init/environment.rb
@@ -19,6 +19,11 @@ class Environment
     self
   end
 
+  def when_production
+    yield if name == 'production'
+    self
+  end
+
   def when_deployed
     yield if %w[production staging].include? name
     self

--- a/spec/models/art_museum_spec.rb
+++ b/spec/models/art_museum_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe ArtMuseum do
   it 'truncates very long queries before sending them to the art museum' do

--- a/spec/models/article_document_spec.rb
+++ b/spec/models/article_document_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe ArticleDocument do
   let(:doc_keys) { [:title, :creator, :publisher, :id, :type, :description, :url, :other_fields] }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Article do
   let(:query_terms) { 'forest' }

--- a/spec/models/catalog_document_spec.rb
+++ b/spec/models/catalog_document_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe CatalogDocument do
   it 'finds the library from the holdings_1display' do

--- a/spec/models/catalog_spec.rb
+++ b/spec/models/catalog_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Catalog do
   describe '#more_link' do

--- a/spec/models/dpul_document_spec.rb
+++ b/spec/models/dpul_document_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe DpulDocument do
   describe '#other_fields' do

--- a/spec/models/libanswers_document_spec.rb
+++ b/spec/models/libanswers_document_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe LibanswersDocument do
   describe '#url' do

--- a/spec/models/libanswers_spec.rb
+++ b/spec/models/libanswers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe Libanswers do
   describe '#more_link' do

--- a/spec/models/libguides_document_spec.rb
+++ b/spec/models/libguides_document_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe LibguidesDocument do
   describe 'creator' do

--- a/spec/models/library_database_spec.rb
+++ b/spec/models/library_database_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe LibraryDatabase do
   let(:query_terms) { 'foo' }

--- a/spec/models/library_staff_document_spec.rb
+++ b/spec/models/library_staff_document_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe LibraryStaffDocument do
   let(:record) do

--- a/spec/models/library_staff_spec.rb
+++ b/spec/models/library_staff_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe LibraryStaff do
   let(:query_terms) { 'foo' }

--- a/spec/models/library_website_document_spec.rb
+++ b/spec/models/library_website_document_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe LibraryWebsiteDocument do
   let(:doc_keys) { [:title, :id, :type, :description, :url, :other_fields] }

--- a/spec/models/library_website_spec.rb
+++ b/spec/models/library_website_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe LibraryWebsite do
   let(:query_terms) { 'firestone' }

--- a/spec/models/normalizer_spec.rb
+++ b/spec/models/normalizer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Normalizer do
   describe '#without_diacritics' do

--- a/spec/models/oauth_token_cache_spec.rb
+++ b/spec/models/oauth_token_cache_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe OAuthTokenCache do
   describe '#token' do

--- a/spec/models/physical_holding_spec.rb
+++ b/spec/models/physical_holding_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe PhysicalHolding do
   describe 'barcode' do

--- a/spec/models/physical_item_spec.rb
+++ b/spec/models/physical_item_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe PhysicalItem do
   describe '#barcode' do

--- a/spec/models/sanitizer_spec.rb
+++ b/spec/models/sanitizer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Sanitizer do
   context 'with a custom scrubber' do

--- a/spec/rack_helper.rb
+++ b/spec/rack_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support/database_cleaner'
+require allsearch_path 'init/environment'
+
+CURRENT_ENVIRONMENT.when_production do
+  abort('The application environment is running in production mode!')
+end
+RSpec.configure do |config|
+  config.include RackTestHelpers
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-require_relative 'support/database_cleaner'
-
-# Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?

--- a/spec/relations/best_bet_relation_spec.rb
+++ b/spec/relations/best_bet_relation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 require allsearch_path 'init/logger'
 
 RSpec.describe BestBetRelation do

--- a/spec/relations/library_database_relation_spec.rb
+++ b/spec/relations/library_database_relation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 # rubocop:disable RSpec/NestedGroups
 RSpec.describe LibraryDatabaseRelation do

--- a/spec/relations/library_staff_relation_spec.rb
+++ b/spec/relations/library_staff_relation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe LibraryStaffRelation do
   let(:rom) { Rails.application.config.rom }

--- a/spec/repositories/banner_repository_spec.rb
+++ b/spec/repositories/banner_repository_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe BannerRepository do
   it 'can get a banner' do

--- a/spec/repositories/library_database_repository_spec.rb
+++ b/spec/repositories/library_database_repository_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe LibraryDatabaseRepository do
   describe '#create_from_csv' do

--- a/spec/requests/art_museum_spec.rb
+++ b/spec/requests/art_museum_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/artmuseum' do
   before do

--- a/spec/requests/article_spec.rb
+++ b/spec/requests/article_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/article' do
   before do

--- a/spec/requests/banner_spec.rb
+++ b/spec/requests/banner_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /banner' do
   before do

--- a/spec/requests/best_bet_spec.rb
+++ b/spec/requests/best_bet_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/best-bet', :truncate do
   let(:google_response) { file_fixture('google_sheets/best_bets.csv') }

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/catalog' do
   let(:response_body) { JSON.parse(last_response.body, symbolize_names: true) }

--- a/spec/requests/cors_spec.rb
+++ b/spec/requests/cors_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 describe 'CORS' do
   before do

--- a/spec/requests/dpul_spec.rb
+++ b/spec/requests/dpul_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/dpul' do
   let(:service_path) { 'dpul' }

--- a/spec/requests/findingaids_spec.rb
+++ b/spec/requests/findingaids_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/findingaids' do
   let(:service_path) { 'findingaids' }

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 def stub_solr_ping(headers: {}, status: 200, **)
   stub_request(:get, %r{http://lib-solr8-prod.princeton.edu:8983/solr/.*/admin/ping}).to_return(headers:, status:,

--- a/spec/requests/journals_spec.rb
+++ b/spec/requests/journals_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/journals' do
   let(:response_body) { JSON.parse(last_response.body, symbolize_names: true) }

--- a/spec/requests/libanswers_spec.rb
+++ b/spec/requests/libanswers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/libanswers' do
   before do

--- a/spec/requests/libguides_spec.rb
+++ b/spec/requests/libguides_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/libguides' do
   before do

--- a/spec/requests/library_database_spec.rb
+++ b/spec/requests/library_database_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/database' do
   let(:libjobs_response) { file_fixture('libjobs/library-databases.csv') }

--- a/spec/requests/library_staff_spec.rb
+++ b/spec/requests/library_staff_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/staff' do
   let(:libjobs_response) { file_fixture('library_staff/staff-directory.csv') }

--- a/spec/requests/library_website_spec.rb
+++ b/spec/requests/library_website_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/website' do
   before do

--- a/spec/requests/main_spec.rb
+++ b/spec/requests/main_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /' do
   it 'renders json' do

--- a/spec/requests/pulmap_spec.rb
+++ b/spec/requests/pulmap_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe 'GET /search/pulmap' do
   before do

--- a/spec/services/best_bet_loading_service_spec.rb
+++ b/spec/services/best_bet_loading_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe BestBetLoadingService, :truncate do
   let(:google_response) { file_fixture('google_sheets/best_bets.csv') }

--- a/spec/services/library_database_loading_service_spec.rb
+++ b/spec/services/library_database_loading_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe LibraryDatabaseLoadingService, :truncate do
   let(:libjobs_response) { file_fixture('libjobs/library-databases.csv') }

--- a/spec/services/library_staff_loading_service_spec.rb
+++ b/spec/services/library_staff_loading_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe LibraryStaffLoadingService, :truncate do
   let(:libjobs_response) { file_fixture('library_staff/staff-directory.csv') }

--- a/spec/services/oauth_service_spec.rb
+++ b/spec/services/oauth_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe OAuthService do
   before do

--- a/spec/services/sample_data_creation_service_spec.rb
+++ b/spec/services/sample_data_creation_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 RSpec.describe SampleDataCreationService do
   describe '#create' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'webmock/rspec'
 require_relative '../app/paths'
 require_relative 'support/fixture_helpers'
-require_relative 'support/rack_helpers'
+require_relative 'support/rack_test_helpers'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/rack_test_helpers.rb
+++ b/spec/support/rack_test_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# These helpers create a full Rack application for testing
+
 require 'rack'
 require 'rack/test'
 
@@ -11,7 +13,4 @@ module RackTestHelpers
   def app
     ALLSEARCH_RACK_APP
   end
-end
-RSpec.configure do |config|
-  config.include RackTestHelpers
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'rack_helper'
 
 # This file defines a DSL that both generates an OpenAPI (aka Swagger) Spec for this application
 # and runs RSpec assertions to confirm that the OpenAPI Spec is accurate.  The DSL is extremely


### PR DESCRIPTION
Move tests that were previously requiring rails_helper with spec_helper (if they don't need a whole Rack
application environment to test) or rack_helper (if they do).