### PR TITLE
Skip nokogiri-based sanitization for strings that don't contain angle brackets

### DIFF
--- a/app/models/sanitizer.rb
+++ b/app/models/sanitizer.rb
@@ -5,14 +5,35 @@ require 'cgi'
 
 class Sanitizer
   def sanitize(html)
-    sanitized = sanitizer_implementation.fragment(html)
-    with_fixed_whitespace = sanitized.strip.gsub(/(?:&nbsp;| )+/, ' ')
-    CGI.unescapeHTML with_fixed_whitespace
+    remove_problematic_html(html)
+      .gsub('&nbsp;', ' ')
+      .squeeze(' ')
+      .strip
   end
 
   private
 
+  def remove_problematic_html(raw)
+    html = raw.to_s
+    if html.include? '<'
+      sanitizer_implementation.fragment(html)
+    else
+      # If there is not an angle bracket, no need to parse it as HTML
+      html
+    end
+  end
+
+  # :reek:FeatureEnvy
   def sanitizer_implementation
-    @sanitizer_implementation ||= Sanitize.new(elements: %w[b em i strong])
+    @sanitizer_implementation ||= begin
+      remove_entities = lambda do |env|
+        node = env[:node]
+        if node.is_a? Nokogiri::XML::Text
+          sanitized = Sanitize.fragment(CGI.unescapeHTML(node.content))
+          sanitized.tr("\u00A0", ' ')
+        end
+      end
+      Sanitize.new(elements: %w[b em i strong], transformers: remove_entities)
+    end
   end
 end

--- a/benchmark/microbenchmarks.rb
+++ b/benchmark/microbenchmarks.rb
@@ -25,3 +25,20 @@ Benchmark.ips do |b|
     library_staff_repo.delete
   end
 end
+
+Benchmark.ips do |b|
+  long_string = <<~END_LONG_STRING
+    •Bayesian networks (BNs) offer an alternative approach to risk estimation.•A BN of mercury risks to panthers replicated traditional probabilistic estimates.•BNs facilitate
+    quantification of uncertainty and causal inference.\nTraditionally hazard quotients (HQs) have been computed for ecological risk assessment, often without quantifying the
+    underlying uncertainties in the risk estimate. We demonstrate a Bayesian network approach to quantitatively assess uncertainties in HQs using a retrospective case study of
+    dietary mercury (Hg) risks to Florida panthers (Puma concolor coryi). The Bayesian network was parameterized, using exposure data from a previous Monte Carlo-based assessment
+    of Hg risks (Barron et al., 2004. ECOTOX 13=>223), as a representative example of the uncertainty and complexity in HQ calculations. Mercury HQs and risks to Florida panthers
+    determined from a Bayesian network analysis were nearly identical to those determined using the prior Monte Carlo probabilistic assessment and demonstrated the ability of the
+    Bayesian network to replicate conventional HQ-based approaches. Sensitivity analysis of the Bayesian network showed greatest influence on risk estimates from daily ingested
+    dose by panthers and mercury levels in prey, and less influence from toxicity reference values. Diagnostic inference was used in a high-risk scenario to demonstrate the
+    capabilities of Bayesian networks for examining probable causes for observed effects. Application of Bayesian networks in the computation of HQs provides a transparent and
+    quantitative analysis of uncertainty in risks."
+  END_LONG_STRING
+  sanitizer = Sanitizer.new
+  b.report('sanitizer') { sanitizer.sanitize long_string }
+end

--- a/spec/models/sanitizer_spec.rb
+++ b/spec/models/sanitizer_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe Sanitizer do
       expect(sanitizer.sanitize(test_string)).to eq(expected)
     end
 
+    it 'does not convert html entities into malicious tags' do
+      test_string = '&lt;script src="example.com"&gt;&lt;/script&gt;<p>This is a test</p>'
+      expected = '&lt;script src="example.com"&gt;&lt;/script&gt; This is a test'
+
+      expect(sanitizer.sanitize(test_string)).to eq(expected)
+    end
+
+    it 'does not convert double html entities into malicious tags' do
+      test_string = '&amp;lt;script src="example.com"&amp;gt;&amp;lt;/script&amp;gt;<p>This is a test</p>'
+      expected = '&amp;lt;script src="example.com"&amp;gt;&amp;lt;/script&amp;gt; This is a test'
+
+      expect(sanitizer.sanitize(test_string)).to eq(expected)
+    end
+
+    it 'keeps meaningful &lt;' do
+      test_string = '5 &lt; 10'
+
+      expect(sanitizer.sanitize(test_string)).to eq(test_string)
+    end
+
     it 'removes link tags' do
       test_string = '<link rel="example.com">This is a test'
       expected = 'This is a test'


### PR DESCRIPTION
It can be expensive to run the full sanitization routine on long strings, so let's skip it if they don't need HTML-parser based sanitization, using the heuristic of checking for an opening angle bracket.

Also, use ruby's squeeze method to avoid an expensive regular expression.

Also, avoid the potential for XSS if the source data has a malicious tag that is encoded with HTML entities (e.g. `&lt;script&gt;` instead of  `<script>`.

According to the attached microbenchmark:

before:
```
Warming up --------------------------------------
           sanitizer   583.000 i/100ms
Calculating -------------------------------------
           sanitizer      6.308k (± 4.5%) i/s  (158.54 μs/i) -     31.482k in   5.001876s
```

after:
```
Warming up --------------------------------------
           sanitizer    31.808k i/100ms
Calculating -------------------------------------
           sanitizer    315.987k (± 3.1%) i/s    (3.16 μs/i) -      1.590M in   5.038977s
```