### PR TITLE
Remove Rails inflection configuration

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.acronym 'CSV'
-  inflect.acronym 'OAuth'
-end


### PR DESCRIPTION
It is no longer used, since we use our own autoloader now (see #465), rather than the Rails-provided one.