### PR TITLE
Replace Time.zone.now with Time.now.utc

### DIFF
--- a/app/models/oauth_token_cache.rb
+++ b/app/models/oauth_token_cache.rb
@@ -31,7 +31,7 @@ class OAuthTokenCache
     repo.find(service:, endpoint:)
         .bind do |existing_entry|
           existing_entry_expiration_time = existing_entry[:expiration_time]
-          if existing_entry_expiration_time && Time.zone.now < existing_entry_expiration_time
+          if existing_entry_expiration_time && Time.now.utc < existing_entry_expiration_time
             Some(existing_entry)
           else
             update_existing_entry(existing_entry[:id])


### PR DESCRIPTION
Since our boxes use UTC, this will be the same, and does not require on Rails timezone handling

Part of #473, since it allows us to remove the Rails timezone initializer.