### PR TITLE
Remove almost all built-in Rails initializers

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,7 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require allsearch_path 'init/all'
+require_relative 'init/all'
 
 require_relative 'config/environment'
 require allsearch_path 'config/allsearch_configs'

--- a/config/initialize_rails.rb
+++ b/config/initialize_rails.rb
@@ -2,23 +2,9 @@
 
 # This class is responsible for initializing the Rails application.
 # It is an override of Rails.application.initialize!
-# We can gradually exclude more of Rails' built-in
-# initializers as we migrate away from Rails
 class InitializeRails
-  INITIALIZERS_TO_EXCLUDE = [
-    :set_autoload_paths, :setup_once_autoloader, :setup_main_autoloader,
-    :set_eager_load, :set_eager_load_paths, :eager_load!,
-    :initialize_logger, :enable_yjit, 'active_support.initialize_beginning_of_week',
-    'active_support.deprecator', 'action_dispatch.deprecator', 'active_model.deprecator',
-    'action_controller.deprecator', 'active_record.deprecator', 'action_view.deprecator',
-    :load_environment_config, :load_environment_config, :load_environment_hook, :load_active_support,
-    :initialize_error_reporter, 'active_support.to_time_preserves_timezone',
-    :initialize_cache, :set_load_path, :set_load_path, :make_routes_lazy, :make_routes_lazy, :bootstrap_hook,
-    'active_support.isolation_level', 'active_support.raise_on_invalid_cache_expiration_time',
-    'active_support.set_authenticated_message_encryption', 'active_support.reset_execution_context',
-    'active_support.reset_all_current_attributes_instances', 'active_support.deprecation_behavior'
-
-  ].freeze
+  INITIALIZERS_TO_INCLUDE = ['active_record.set_configs', 'active_record.initialize_database',
+                             :load_config_initializers].freeze
 
   def initialize(application = Rails.application)
     @application = application
@@ -37,7 +23,7 @@ class InitializeRails
   def initializers_to_run
     @initializers_to_run ||= application.initializers.tsort_each
                                         .select { it.belongs_to? :default }
-                                        .reject { INITIALIZERS_TO_EXCLUDE.include? it.name }
+                                        .select { INITIALIZERS_TO_INCLUDE.include? it.name }
   end
 
   def rails_initializers_have_run?


### PR DESCRIPTION
Only `:load_config_initializers` and some activerecord-related ones remain.  Helps with #473 