### PR TITLE
Fix ROM error when running the best-bet rake task in servers:start

### DIFF
--- a/lib/tasks/best_bets.rake
+++ b/lib/tasks/best_bets.rake
@@ -3,7 +3,7 @@
 require_relative '../../init/rom_factory'
 namespace :best_bets do
   desc 'Refresh the best_bet_documents table with data from the spreadsheet'
-  task sync: :autoload do
-    BestBetLoadingService.new.run
+  task sync: [:autoload, :database_connection] do
+    BestBetLoadingService.new(rom_container: ALLSEARCH_ROM).run
   end
 end


### PR DESCRIPTION
Before this commit, we got the following error when we ran `rake servers:start`:

```
NoMethodError: undefined method 'rom' for an instance of Rails::Application::Configuration (NoMethodError)
Did you mean?  root
```