### PR TITLE
Drop and re-create database in Sequel rather than using the Rails rake tasks

### DIFF
--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -2,18 +2,26 @@
 
 namespace :servers do
   desc 'Start development servers'
-  task initialize: :environment do
-    Rake::Task['db:drop'].invoke
-    Rake::Task['db:create'].invoke
+  task :initialize do
+    require 'sequel'
+    db_server_config = ALLSEARCH_CONFIGS[:database].except(:database)
+    Sequel.connect(db_server_config) do |db|
+      # Drop active connections to the relevant database
+      db.run 'SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity ' \
+             "WHERE pg_stat_activity.datname = '#{ALLSEARCH_CONFIGS[:database][:database]}' AND pid <> pg_backend_pid()"
+      db.run "DROP DATABASE IF EXISTS #{ALLSEARCH_CONFIGS[:database][:database]}"
+      db.run "CREATE DATABASE #{ALLSEARCH_CONFIGS[:database][:database]}"
+    end
+
     Rake::Task['db:migrate'].invoke
   end
 
   desc 'Start the Apache Solr and PostgreSQL container services using Lando.'
-  task start: :environment do
+  task :start do
     Rake::Task['solr:update_configs'].invoke
     system('lando start')
     system('bundle exec rake servers:initialize')
-    system('APP_ENV=test bundle exec rake db:migrate')
+    system('APP_ENV=test bundle exec rake servers:initialize')
     system('bundle exec rake solr:load_sample_data')
     system('bundle exec rake best_bets:sync')
   end


### PR DESCRIPTION
This addresses the following error in `bundle exec rake servers:start`:

```
rake aborted!
Could not connect to the database: PG::ConnectionBad: connection to server at "127.0.0.1", port 64340 failed: FATAL:  database "allsearch_development" does not exist
/Users/christinachortaria/apps_team/allsearch_api/init/rom_factory.rb:24:in 'block in RomFactory#require_rom!'
/Users/christinachortaria/apps_team/allsearch_api/init/rom_factory.rb:24:in 'RomFactory#require_rom!'
/Users/christinachortaria/apps_team/allsearch_api/lib/tasks/database_connection.rake:6:in 'block in <main>'
```